### PR TITLE
fix(release): handle pnpm -- separator in arg parser

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -63,6 +63,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --dry-run) DRY_RUN=true; shift ;;
+    --) shift ;;
     -h|--help)
       echo "Usage: scripts/release.sh [--patch|--minor|--major|--version X.Y.Z] [--dry-run]"
       echo ""


### PR DESCRIPTION
## Summary
- Release script rejected `--` passed by pnpm when running `pnpm release -- --version 0.1.0`
- Added `--) shift ;;` case to the arg parser to silently skip the separator

## Test plan
- [x] `pnpm release:dry -- --version 0.1.0` no longer errors on `--`