### PR TITLE
docs: rework onboarding for tiered progressive experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,41 @@ Source -> [Transform] -> Route -> Actor
 
 ---
 
-## Quick Demo
+## Try It
+
+Set up a webhook source and a console logger, then route an event between them.
 
 ```bash
-orgloop init --name my-org --connectors github,linear,claude-code,openclaw --no-interactive
-orgloop add module engineering    # Install engineering workflow
-orgloop doctor                    # Check deps + credentials
-orgloop plan                      # Preview what will run
-orgloop apply                     # Start the runtime
-orgloop status                    # See everything flowing
+npm install -g @orgloop/cli
+orgloop init    # select "webhook" when prompted for connectors
+cd my-org
+orgloop add module minimal
+orgloop apply
+```
+
+In another terminal, send an event:
+
+```bash
+curl -X POST http://localhost:3000/webhook \
+  -H "Content-Type: application/json" \
+  -d '{"type": "test", "message": "hello from orgloop"}'
+```
+
+You should see the event flow through the system and appear in your console log. That's the core loop: source emits, route matches, actor delivers, logger observes.
+
+---
+
+## What It Grows Into
+
+When you're ready to wire up real services, OrgLoop scales to a full engineering organization:
+
+```bash
+orgloop init    # select github, linear, claude-code, openclaw
+orgloop add module engineering
+orgloop doctor        # Check deps + credentials
+orgloop plan          # Preview what will run
+orgloop apply         # Start the runtime
+orgloop status        # See everything flowing
 ```
 
 ```
@@ -44,6 +70,16 @@ Routes:
   linear-to-project           12 matched, 0 errors
   claude-code-to-supervisor    3 matched, 0 errors
 ```
+
+**Prerequisites for the full engineering workflow:**
+
+- Node.js >= 22
+- GitHub account + [personal access token](https://github.com/settings/tokens) with `repo` read access
+- Linear account + [API key](https://linear.app/settings/api)
+- Claude Code installed locally
+- OpenClaw running locally
+
+See the **[Getting Started guide](https://orgloop.ai/start/getting-started/)** for step-by-step setup.
 
 ---
 
@@ -108,29 +144,6 @@ loggers:
 - **Full observability** -- every event, transform, delivery logged and traceable
 - **One process replaces N pollers** -- no more scattered LaunchAgents and cron jobs
 - **`plan` before `apply`** -- see exactly what will change (Terraform-style)
-
----
-
-## Getting Started
-
-```bash
-# Install
-npm install -g @orgloop/cli
-
-# Scaffold a project
-orgloop init --name my-org --connectors github,linear,claude-code,openclaw --no-interactive
-orgloop add module engineering
-
-# Check dependencies and credentials
-orgloop doctor
-
-# Validate, plan, apply
-orgloop validate
-orgloop plan
-orgloop apply
-```
-
-**[Full Getting Started Guide ->](https://orgloop.ai/start/getting-started/)**
 
 ---
 

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -44,9 +44,9 @@ export default defineConfig({
 				{
 					label: 'Examples',
 					items: [
-						{ label: 'Minimal', slug: 'examples/minimal' },
-						{ label: 'Engineering Org', slug: 'examples/engineering-org' },
+						{ label: 'Minimal (Start Here)', slug: 'examples/minimal' },
 						{ label: 'GitHub to Slack', slug: 'examples/github-to-slack' },
+						{ label: 'Engineering Org', slug: 'examples/engineering-org' },
 						{ label: 'Multi-Agent Supervisor', slug: 'examples/multi-agent-supervisor' },
 						{ label: 'Beyond Engineering', slug: 'examples/beyond-engineering' },
 						{ label: 'Org-to-Org', slug: 'examples/org-to-org' },

--- a/docs-site/src/content/docs/examples/engineering-org.md
+++ b/docs-site/src/content/docs/examples/engineering-org.md
@@ -3,7 +3,15 @@ title: "Example: Engineering Org"
 description: Full engineering organization — GitHub, Linear, Claude Code routing to OpenClaw agents.
 ---
 
-A complete engineering organization: three sources (GitHub, Linear, Claude Code) route events through a filter and dedup pipeline to an OpenClaw agent. This replaces a collection of bespoke cron jobs and shell scripts with a single declarative config.
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="caution" title="Prerequisites: 4 services">
+This example requires accounts and tokens for **GitHub**, **Linear**, **Claude Code**, and **OpenClaw**. If you are new to OrgLoop, start with the [Minimal](/examples/minimal/) or [GitHub to Slack](/examples/github-to-slack/) examples first, then come back here.
+</Aside>
+
+A complete engineering organization: three sources (GitHub, Linear, Claude Code) route events through a filter and dedup pipeline to an [OpenClaw](https://openclaw.ai) agent. This replaces a collection of bespoke cron jobs and shell scripts with a single declarative config.
+
+**What is OpenClaw?** OpenClaw is an AI agent orchestration platform that receives events via webhooks and dispatches work to AI agents (like Claude Code). It acts as the "actor" in this setup -- OrgLoop routes events to OpenClaw, and OpenClaw manages the agent sessions.
 
 ## Architecture
 
@@ -15,22 +23,31 @@ Claude Code (hook)──┘
 
 Three sources emit events. Two transforms clean them. Five routes wire specific event types to the actor with appropriate SOPs (launch prompts).
 
+## Prerequisites
+
+- Node.js >= 22
+- OrgLoop CLI installed (`npm install -g @orgloop/cli`)
+- A [GitHub](https://github.com) account with a repository to monitor
+- A [Linear](https://linear.app) account with an engineering team
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed locally
+- An [OpenClaw](https://openclaw.ai) instance running (local or hosted)
+
 ## Environment variables
 
 | Variable | Source | Description |
 |----------|--------|-------------|
 | `GITHUB_REPO` | GitHub | Repository in `owner/repo` format |
-| `GITHUB_TOKEN` | [GitHub PAT](https://github.com/settings/tokens) | Personal access token with repo read access |
-| `LINEAR_TEAM_KEY` | Linear | Team key (e.g., `ENG`) |
-| `LINEAR_API_KEY` | [Linear Settings](https://linear.app/settings/api) | Linear API key |
-| `OPENCLAW_WEBHOOK_TOKEN` | OpenClaw | Bearer token for OpenClaw API |
-| `OPENCLAW_DEFAULT_TO` | OpenClaw | Default message recipient |
+| `GITHUB_TOKEN` | [GitHub PAT](https://github.com/settings/tokens) | Personal access token with `repo` read access |
+| `LINEAR_TEAM_KEY` | [Linear](https://linear.app) | Team key (e.g., `ENG`) -- find it in your team's settings |
+| `LINEAR_API_KEY` | [Linear API Settings](https://linear.app/settings/api) | Personal API key |
+| `OPENCLAW_WEBHOOK_TOKEN` | [OpenClaw](https://openclaw.ai) | Bearer token for OpenClaw API |
+| `OPENCLAW_DEFAULT_TO` | [OpenClaw](https://openclaw.ai) | Default message recipient |
 
 ## Setup
 
 ```bash
 # Scaffold
-orgloop init --name my-org --connectors github,linear,openclaw,claude-code --no-interactive --dir my-org
+orgloop init    # select github, linear, openclaw, claude-code
 cd my-org
 orgloop add module engineering
 

--- a/docs-site/src/content/docs/examples/github-to-slack.md
+++ b/docs-site/src/content/docs/examples/github-to-slack.md
@@ -3,7 +3,13 @@ title: "Example: GitHub to Slack"
 description: Single source, single actor — GitHub PR events to Slack notifications.
 ---
 
-The simplest real-world OrgLoop setup: one GitHub source, one Slack webhook actor, one route. Two minutes from clone to running.
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="note" title="Prerequisites: 2 tokens">
+This example requires a **GitHub personal access token** and a **Slack incoming webhook URL**. If you do not have these yet, see the setup instructions below -- each takes about 1 minute to create.
+</Aside>
+
+The simplest real-world OrgLoop setup: one GitHub source, one Slack webhook actor, one route. About 5 minutes from clone to running (including token setup).
 
 ## What this example shows
 
@@ -19,7 +25,7 @@ The simplest real-world OrgLoop setup: one GitHub source, one Slack webhook acto
 - A GitHub personal access token with `repo` read access
 - A Slack incoming webhook URL
 
-## Setup (2 minutes)
+## Setup (~5 minutes)
 
 ### 1. Get your tokens
 

--- a/docs-site/src/content/docs/examples/minimal.md
+++ b/docs-site/src/content/docs/examples/minimal.md
@@ -3,6 +3,12 @@ title: "Example: Minimal"
 description: The simplest possible OrgLoop setup — one source, one logger.
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="Start here">
+This is the best place to start with OrgLoop. A webhook source and a console logger -- one route connecting them. No external services required.
+</Aside>
+
 The simplest possible OrgLoop setup. One webhook source, one console logger, no environment variables. Use this to understand the config format before building anything real.
 
 ## What this example shows
@@ -15,6 +21,7 @@ The simplest possible OrgLoop setup. One webhook source, one console logger, no 
 
 - Node.js >= 22
 - OrgLoop CLI installed (`npm install -g @orgloop/cli`)
+- **No accounts or API tokens required**
 
 ## Setup
 
@@ -30,7 +37,7 @@ orgloop apply
 Or scaffold from scratch:
 
 ```bash
-orgloop init --name my-project --connectors webhook --no-interactive --dir my-project
+orgloop init    # select "webhook" when prompted for connectors
 cd my-project
 orgloop validate
 orgloop apply
@@ -123,4 +130,8 @@ Since this example has no routes or actors, events are ingested and logged but n
 
 ## Next steps
 
-Ready for something real? See the [GitHub to Slack](/examples/github-to-slack/) example for a single source-to-actor pipeline, or the [Engineering Org](/examples/engineering-org/) example for a full multi-source setup.
+Once you are comfortable with the config format, add a real source:
+
+- **[GitHub to Slack](/examples/github-to-slack/)** -- one source, one actor, two tokens. The simplest real-world setup.
+- **[Multi-Agent Supervisor](/examples/multi-agent-supervisor/)** -- the feedback loop pattern with Claude Code and a supervisor agent.
+- **[Engineering Org](/examples/engineering-org/)** -- the full multi-source setup with GitHub, Linear, Claude Code, and OpenClaw.

--- a/docs-site/src/content/docs/examples/multi-agent-supervisor.md
+++ b/docs-site/src/content/docs/examples/multi-agent-supervisor.md
@@ -3,6 +3,12 @@ title: "Example: Multi-Agent Supervisor"
 description: Feedback loop pattern — actor completion events route back to a supervisor agent.
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="caution" title="Prerequisites: 3 services">
+This example requires **GitHub**, **Claude Code**, and **OpenClaw**. If you are new to OrgLoop, start with the [Minimal](/examples/minimal/) example first (no accounts needed), then come back here.
+</Aside>
+
 The feedback loop pattern -- the defining feature of OrgLoop. Claude Code sessions emit `actor.stopped` events, which route to a supervisor actor that reviews work and can re-dispatch tasks. The supervisor's own completions feed back into the system, creating a recursive loop.
 
 ## What this example shows
@@ -40,8 +46,9 @@ The loop sustains itself. Every actor completion is an event. Every event can be
 
 - Node.js >= 22
 - OrgLoop CLI installed (`npm install -g @orgloop/cli`)
-- An OpenClaw instance running locally
-- Claude Code installed (for the post-exit hook)
+- A [GitHub](https://github.com) account with a repository to monitor
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed locally (for the post-exit hook)
+- An [OpenClaw](https://openclaw.ai) instance running locally -- OpenClaw is an AI agent orchestration platform that manages agent sessions
 
 ## Setup
 
@@ -50,9 +57,9 @@ The loop sustains itself. Every actor completion is an event. Every event can be
 | Variable | Description | Where to get it |
 |----------|-------------|-----------------|
 | `GITHUB_REPO` | Repository being worked on (`owner/repo`) | Your GitHub repo URL |
-| `GITHUB_TOKEN` | GitHub PAT with repo read access | [GitHub Settings](https://github.com/settings/tokens) |
-| `OPENCLAW_WEBHOOK_TOKEN` | Bearer token for OpenClaw API | Your OpenClaw instance |
-| `OPENCLAW_DEFAULT_TO` | Default message recipient | Your team configuration |
+| `GITHUB_TOKEN` | GitHub PAT with `repo` read access | [GitHub Settings > Tokens](https://github.com/settings/tokens) |
+| `OPENCLAW_WEBHOOK_TOKEN` | Bearer token for OpenClaw API | Your [OpenClaw](https://openclaw.ai) instance |
+| `OPENCLAW_DEFAULT_TO` | Default message recipient | Your OpenClaw team configuration |
 
 ### 2. Install the Claude Code hook
 

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -9,6 +9,27 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 [Get Started](/start/getting-started/) | [View on GitHub](https://github.com/c-h-/orgloop)
 
+## Try It Now
+
+Set up a webhook source and a console logger, route an event between them.
+
+```bash
+npm install -g @orgloop/cli
+orgloop init    # select "webhook" when prompted for connectors
+cd my-org && orgloop add module minimal
+orgloop validate && orgloop apply
+```
+
+In another terminal:
+
+```bash
+curl -X POST http://localhost:3000/webhook \
+  -H "Content-Type: application/json" \
+  -d '{"type": "test", "message": "hello from orgloop"}'
+```
+
+You just routed an event through OrgLoop. The [Getting Started guide](/start/getting-started/) walks you through connecting GitHub, Linear, and a full autonomous engineering org -- one tier at a time.
+
 ## Why OrgLoop
 
 You're running AI agents. Each one is genuinely capable. And yet you're still the glue.
@@ -45,23 +66,9 @@ When an actor finishes work, that completion is itself an event -- routed back i
 	</Card>
 </CardGrid>
 
-## Quick Demo
+## What It Grows Into
 
-```bash
-# Scaffold a project with connectors
-orgloop init --name my-org --connectors github,linear,openclaw,claude-code --no-interactive
-
-# Install a pre-built workflow module
-orgloop add module engineering
-
-# Check environment variables
-orgloop env
-
-# Start the engine
-orgloop apply
-```
-
-Once running, `orgloop status` shows your organization in action:
+Connect real systems and `orgloop status` shows your organization in action:
 
 ```
 OrgLoop — my-org (running, uptime 3h 22m)
@@ -117,6 +124,17 @@ routes:
 
 Read that and you see an organization's nervous system. Every event that matters, where it goes, what responds. If there's a gap -- a lifecycle event with no route -- it's visible.
 
+## Examples
+
+Each example is a self-contained project you can copy and run. They're ordered by complexity:
+
+| Example | What you need | What you get |
+|---------|--------------|--------------|
+| [**Minimal**](/examples/minimal/) | Nothing | Webhook in, console out. Learn the config format. |
+| [**GitHub to Slack**](/examples/github-to-slack/) | GitHub token, Slack webhook | Real PR events → Slack notifications |
+| [**Engineering Org**](/examples/engineering-org/) | GitHub, Linear, Claude Code, OpenClaw | Full autonomous engineering org with 5 routes |
+| [**Multi-Agent Supervisor**](/examples/multi-agent-supervisor/) | GitHub, Claude Code, OpenClaw | The feedback loop: actor completion → supervisor → re-dispatch |
+
 ## Get Started
 
-Ready to try it? Follow the [Getting Started guide](/start/getting-started/) to go from zero to a running system in five minutes. Or read [What is OrgLoop?](/start/what-is-orgloop/) for a deeper introduction to Organization as Code.
+The [Getting Started guide](/start/getting-started/) walks you through three tiers: a local webhook (2 min), connecting GitHub (10 min), and a full autonomous engineering org (30 min). Or read [What is OrgLoop?](/start/what-is-orgloop/) for a deeper introduction to Organization as Code.

--- a/docs-site/src/content/docs/start/what-is-orgloop.md
+++ b/docs-site/src/content/docs/start/what-is-orgloop.md
@@ -35,7 +35,7 @@ Same shift that happened with servers. SSH'ing into machines and tweaking config
 
 Your event sources, your actors, your wiring -- all declared in config. Auditable. No hidden state, no tribal knowledge, no human glue.
 
-Here's what a minimum viable autonomous engineering org looks like:
+Here's what a minimum viable autonomous engineering org looks like. This example uses GitHub, Linear, Claude Code, and OpenClaw. The [Getting Started guide](/start/getting-started/) walks through setting these up step by step -- starting with a zero-dependency demo.
 
 ```yaml
 sources:
@@ -170,6 +170,12 @@ Same actor, different prompts per route. The routing layer decides which SOP is 
 
 ## Next steps
 
-Ready to try it? The [Getting Started guide](/start/getting-started/) takes you from zero to a running system in five minutes.
+Ready to try it? The [Getting Started guide](/start/getting-started/) walks you through three tiers:
+
+1. **Try it now** -- a zero-dependency demo you can run in 2 minutes with no accounts or tokens
+2. **One real source** -- connect GitHub or Linear and see real events flow
+3. **Full engineering org** -- the complete setup shown above, with all four connectors wired together
+
+Start wherever makes sense for you. Most people start with the demo and add connectors as they go.
 
 For day-to-day operations, see the [User Guide](/start/user-guide/). For deeper architecture, see [Architecture](/concepts/architecture/).

--- a/examples/engineering-org/README.md
+++ b/examples/engineering-org/README.md
@@ -1,21 +1,32 @@
 # Engineering Org Example
 
-A full engineering organization setup: GitHub, Linear, and Claude Code sources route events through transforms to an OpenClaw agent.
+A full engineering organization setup: GitHub, Linear, and Claude Code sources route events through transforms to an [OpenClaw](https://openclaw.ai) agent (an AI agent orchestration platform that dispatches work to AI agents like Claude Code).
 
 ## What it does
 
 - **GitHub** polls for PR reviews, comments, CI failures, and merges
 - **Linear** polls for ticket state changes and comments
-- **Claude Code** receives session completion events via webhook hook
+- **Claude Code** receives session completion events via post-exit hook
 - **Transforms** drop bot noise and deduplicate events
 - **OpenClaw** agent receives filtered events with launch prompts (SOPs)
 
 This replaces a collection of bespoke cron jobs and shell scripts with a single declarative config.
 
+## Prerequisites
+
+- Node.js >= 22
+- OrgLoop CLI installed (`npm install -g @orgloop/cli`)
+- A [GitHub](https://github.com) account with a repository to monitor
+- A [Linear](https://linear.app) account with an engineering team
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed locally
+- An [OpenClaw](https://openclaw.ai) instance running (local or hosted)
+
+> **New to OrgLoop?** Start with the [Minimal](../minimal/) example first -- no accounts or tokens required.
+
 ## Setup
 
 ```bash
-orgloop init --name my-org --connectors github,linear,openclaw,claude-code --no-interactive --dir my-org
+orgloop init    # select github, linear, openclaw, claude-code
 cd my-org
 orgloop add module engineering
 ```
@@ -25,11 +36,11 @@ orgloop add module engineering
 | Variable | Source | Description |
 |----------|--------|-------------|
 | `GITHUB_REPO` | GitHub | Repository in `owner/repo` format |
-| `GITHUB_TOKEN` | GitHub | Personal access token with repo read access |
-| `LINEAR_TEAM_KEY` | Linear | Team key (e.g., `ENG`) |
-| `LINEAR_API_KEY` | Linear | Linear API key |
-| `OPENCLAW_WEBHOOK_TOKEN` | OpenClaw | Bearer token for OpenClaw API |
-| `OPENCLAW_DEFAULT_TO` | OpenClaw | Default message recipient |
+| `GITHUB_TOKEN` | [GitHub PAT](https://github.com/settings/tokens) | Personal access token with `repo` read access |
+| `LINEAR_TEAM_KEY` | [Linear](https://linear.app) | Team key (e.g., `ENG`) |
+| `LINEAR_API_KEY` | [Linear API Settings](https://linear.app/settings/api) | Personal API key |
+| `OPENCLAW_WEBHOOK_TOKEN` | [OpenClaw](https://openclaw.ai) | Bearer token for OpenClaw API |
+| `OPENCLAW_DEFAULT_TO` | [OpenClaw](https://openclaw.ai) | Default message recipient |
 
 ### Install Claude Code hook
 

--- a/examples/github-to-slack/README.md
+++ b/examples/github-to-slack/README.md
@@ -7,7 +7,14 @@ Single GitHub source, single Slack webhook actor, one route. The simplest real-w
 - Polls a GitHub repository for PR reviews and comments
 - Sends notifications to a Slack channel via incoming webhook
 
-## Setup (2 minutes)
+## Prerequisites
+
+- Node.js >= 22
+- OrgLoop CLI installed (`npm install -g @orgloop/cli`)
+- A [GitHub personal access token](https://github.com/settings/tokens) with `repo` read access
+- A [Slack incoming webhook URL](https://api.slack.com/messaging/webhooks)
+
+## Setup (~5 minutes)
 
 ### 1. Get your tokens
 

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -1,6 +1,6 @@
 # Minimal Example
 
-The simplest possible OrgLoop setup: one source, one logger.
+**Start here.** The simplest possible OrgLoop setup: a webhook source and a console logger, one route connecting them.
 
 ## What it does
 
@@ -9,10 +9,16 @@ The simplest possible OrgLoop setup: one source, one logger.
 
 This is the starting point for understanding OrgLoop's config format.
 
+## Prerequisites
+
+- Node.js >= 22
+- OrgLoop CLI installed (`npm install -g @orgloop/cli`)
+- **No accounts or API tokens required**
+
 ## Setup
 
 ```bash
-orgloop init --name my-project --connectors webhook --no-interactive --dir my-project
+orgloop init    # select "webhook" when prompted for connectors
 cd my-project
 orgloop add module minimal
 orgloop validate

--- a/examples/multi-agent-supervisor/README.md
+++ b/examples/multi-agent-supervisor/README.md
@@ -2,11 +2,21 @@
 
 Demonstrates the feedback loop pattern: Claude Code sessions emit `actor.stopped` events, which route to a supervisor actor that reviews work and can re-dispatch tasks.
 
+> **New to OrgLoop?** Start with the [Minimal](../minimal/) example first -- no accounts or tokens required.
+
+## Prerequisites
+
+- Node.js >= 22
+- OrgLoop CLI installed (`npm install -g @orgloop/cli`)
+- A [GitHub](https://github.com) account with a repository to monitor
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed locally
+- An [OpenClaw](https://openclaw.ai) instance running locally
+
 ## What it does
 
-- **Claude Code** connector receives session exit events via webhook hook
+- **Claude Code** connector receives session exit events via post-exit hook
 - **GitHub** connector polls for PR activity (the work Claude Code produces)
-- A **supervisor** actor receives both streams and decides what to do next
+- A **supervisor** actor (via [OpenClaw](https://openclaw.ai)) receives both streams and decides what to do next
 - The supervisor's own sessions feed back as `actor.stopped` events, creating the recursive loop
 
 This is OrgLoop's core insight in action: actors complete sessions, the system observes the completion, and routes it to the next actor in the chain.
@@ -33,12 +43,12 @@ Claude Code session ends
 
 ### 1. Environment variables
 
-| Variable | Description |
-|----------|-------------|
-| `GITHUB_REPO` | Repository being worked on (`owner/repo`) |
-| `GITHUB_TOKEN` | GitHub PAT with repo read access |
-| `OPENCLAW_WEBHOOK_TOKEN` | Bearer token for OpenClaw API |
-| `OPENCLAW_DEFAULT_TO` | Default message recipient |
+| Variable | Description | Where to get it |
+|----------|-------------|-----------------|
+| `GITHUB_REPO` | Repository being worked on (`owner/repo`) | Your GitHub repo URL |
+| `GITHUB_TOKEN` | GitHub PAT with `repo` read access | [GitHub Settings > Tokens](https://github.com/settings/tokens) |
+| `OPENCLAW_WEBHOOK_TOKEN` | Bearer token for OpenClaw API | Your [OpenClaw](https://openclaw.ai) instance |
+| `OPENCLAW_DEFAULT_TO` | Default message recipient | Your OpenClaw team configuration |
 
 ### 2. Install Claude Code hook
 


### PR DESCRIPTION
## Summary

Reworks the entire onboarding surface to get users to the "aha!" moment as fast as possible (WQ-63).

**The core problem:** Every onboarding path previously pushed users toward setting up 4 external services (GitHub, Linear, Claude Code, OpenClaw) before they could see a single event flow. Users abandon.

**The fix:** A tiered funnel where users see value at every step:

| Tier | Time | What you need | What you get |
|------|------|--------------|--------------|
| 1. See It Work | ~2 min | Nothing | Webhook → console, event routing working |
| 2. Connect to GitHub | ~10 min | 1 token | Real PR/CI events flowing through OrgLoop |
| 3. Full Engineering Org | ~30 min | 4 services | Autonomous AI org with supervision loop |

### Changes across 15 files:

- **README**: "Try It" with webhook demo is now the first code block; full org moved to "What It Grows Into" with honest prerequisites
- **Getting Started**: Restructured into 3 tiers with summary table; each tier self-contained
- **Docs-site index**: "Try It Now" section before "Why OrgLoop"
- **Examples**: Reordered by complexity in sidebar; Minimal labeled "(Start Here)"; all examples have clear prerequisites with links
- **Engineering Org example**: Explains what OpenClaw IS; caution callout about 4-service requirement
- **Manifesto**: YAML snippets updated to match real config syntax
- **Interactive init**: All onboarding docs now use `orgloop init` (interactive wizard) instead of `--no-interactive`
- **FE-21**: Transform failure policy design gap captured (fail-open vs fail-closed for security transforms)
- **FE-22**: Module trust & permissions design gap captured

## Test plan

- [x] Docs site builds clean (46 pages, no errors)
- [x] Pre-push hook passes (build, test, typecheck, lint)
- [x] Visual review of docs site locally (`cd docs-site && npm run dev`)
- [x] Walk through Tier 1 from scratch on a clean machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)