### PR TITLE
fix(cli): module packaging, hook UX, name expansion revert, e2e tests

### DIFF
--- a/modules/engineering/package.json
+++ b/modules/engineering/package.json
@@ -7,6 +7,9 @@
   "files": [
     "orgloop-module.yaml",
     "templates",
+    "transforms",
+    "connectors",
+    "loggers",
     "sops"
   ],
   "keywords": [

--- a/packages/cli/src/__tests__/module-e2e.test.ts
+++ b/packages/cli/src/__tests__/module-e2e.test.ts
@@ -10,7 +10,6 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import yaml from 'js-yaml';
 import {
-	expandModuleName,
 	expandModuleRoutes,
 	loadModuleManifest,
 	resolveModulePath,
@@ -96,30 +95,6 @@ describe('loadModuleManifest', () => {
 	});
 });
 
-// ─── Short name expansion ────────────────────────────────────────────────────
-
-describe('expandModuleName', () => {
-	it('expands bare names to scoped packages', () => {
-		expect(expandModuleName('engineering')).toBe('@orgloop/module-engineering');
-		expect(expandModuleName('minimal')).toBe('@orgloop/module-minimal');
-		expect(expandModuleName('custom-module')).toBe('@orgloop/module-custom-module');
-	});
-
-	it('preserves scoped package names', () => {
-		expect(expandModuleName('@orgloop/module-engineering')).toBe('@orgloop/module-engineering');
-		expect(expandModuleName('@other/module')).toBe('@other/module');
-	});
-
-	it('preserves relative paths', () => {
-		expect(expandModuleName('./modules/engineering')).toBe('./modules/engineering');
-		expect(expandModuleName('../my-module')).toBe('../my-module');
-	});
-
-	it('preserves absolute paths', () => {
-		expect(expandModuleName('/opt/modules/custom')).toBe('/opt/modules/custom');
-	});
-});
-
 // ─── Module path resolution ──────────────────────────────────────────────────
 
 describe('resolveModulePath', () => {
@@ -139,10 +114,10 @@ describe('resolveModulePath', () => {
 		expect(result).toContain('node_modules');
 	});
 
-	it('expands short names and attempts npm resolution', () => {
-		// "engineering" → "@orgloop/module-engineering" → npm resolution
-		const result = resolveModulePath('engineering', '/home/user/project');
-		expect(result).toContain('@orgloop/module-engineering');
+	it('rejects bare names with a helpful error', () => {
+		expect(() => resolveModulePath('engineering', '/home/user/project')).toThrow(
+			'Unknown module "engineering". Use a fully qualified package name (e.g. @orgloop/module-engineering) or a local path (e.g. ./modules/engineering).',
+		);
 	});
 });
 

--- a/packages/cli/src/__tests__/readme-e2e.test.ts
+++ b/packages/cli/src/__tests__/readme-e2e.test.ts
@@ -1,0 +1,269 @@
+/**
+ * README onboarding e2e test — validates the full init → add module → doctor → plan flow.
+ *
+ * Exercises the onboarding flow described in the README programmatically:
+ *   1. orgloop init (non-interactive, with connectors)
+ *   2. orgloop add module engineering (non-interactive, with --path)
+ *   3. orgloop doctor (should report 0 errors)
+ *   4. orgloop plan (should produce a valid plan)
+ *
+ * Uses the local CLI binary and a temp directory.
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+// ─── Paths ────────────────────────────────────────────────────────────────────
+
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+const CLI_BIN = join(REPO_ROOT, 'packages', 'cli', 'dist', 'index.js');
+const ENGINEERING_MODULE = join(REPO_ROOT, 'modules', 'engineering');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+let testDir: string;
+
+/** Dummy env vars so config loading / env var substitution does not throw. */
+const DUMMY_ENV: Record<string, string> = {
+	GITHUB_TOKEN: 'ghp_test_dummy_token',
+	GITHUB_REPO: 'test-org/test-repo',
+	GITHUB_WATCHED: 'test-user',
+	LINEAR_API_KEY: 'lin_test_dummy_key',
+	LINEAR_TEAM_KEY: 'TEST',
+	OPENCLAW_WEBHOOK_TOKEN: 'oc_test_dummy_token',
+	OPENCLAW_AGENT_ID: 'test-agent',
+};
+
+/**
+ * Run CLI command. Returns stdout. By default throws on non-zero exit.
+ * Pass `allowFailure: true` to capture output even when the process exits non-zero
+ * (e.g., doctor exits 1 for degraded status).
+ */
+function cli(args: string, cwd: string, opts?: { allowFailure?: boolean }): string {
+	try {
+		return execSync(`node ${CLI_BIN} ${args}`, {
+			cwd,
+			encoding: 'utf-8',
+			env: { ...process.env, ...DUMMY_ENV, NO_COLOR: '1' },
+			timeout: 30_000,
+		});
+	} catch (err: unknown) {
+		if (opts?.allowFailure && err && typeof err === 'object' && 'stdout' in err) {
+			return (err as { stdout: string }).stdout;
+		}
+		throw err;
+	}
+}
+
+beforeEach(async () => {
+	testDir = join(
+		tmpdir(),
+		`orgloop-readme-e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	await mkdir(testDir, { recursive: true });
+});
+
+afterEach(async () => {
+	await rm(testDir, { recursive: true, force: true });
+});
+
+// ─── Step 1: orgloop init ─────────────────────────────────────────────────────
+
+describe('README onboarding flow', () => {
+	it('init → add module → doctor → plan completes successfully', async () => {
+		// ── Step 1: init ──────────────────────────────────────────────────
+		const initOutput = cli(
+			'init --no-interactive --name test-org --connectors github,linear,openclaw,claude-code --dir .',
+			testDir,
+		);
+
+		// Verify scaffolded files
+		expect(existsSync(join(testDir, 'orgloop.yaml'))).toBe(true);
+		expect(existsSync(join(testDir, 'connectors', 'github.yaml'))).toBe(true);
+		expect(existsSync(join(testDir, 'connectors', 'linear.yaml'))).toBe(true);
+		expect(existsSync(join(testDir, 'connectors', 'openclaw.yaml'))).toBe(true);
+		expect(existsSync(join(testDir, 'connectors', 'claude-code.yaml'))).toBe(true);
+		expect(existsSync(join(testDir, 'routes', 'example.yaml'))).toBe(true);
+		expect(existsSync(join(testDir, 'transforms', 'transforms.yaml'))).toBe(true);
+		expect(existsSync(join(testDir, 'loggers', 'default.yaml'))).toBe(true);
+		expect(existsSync(join(testDir, 'sops', 'example.md'))).toBe(true);
+		expect(existsSync(join(testDir, '.env.example'))).toBe(true);
+
+		// ── Step 2: add module engineering ─────────────────────────────────
+		const addOutput = cli(
+			`add module engineering --path ${ENGINEERING_MODULE} --no-interactive`,
+			testDir,
+		);
+
+		expect(addOutput).toContain('Found module: engineering');
+		expect(addOutput).toContain('Module "engineering" installed');
+
+		// Verify module scaffolded its files (connectors, transforms, SOPs)
+		expect(existsSync(join(testDir, 'sops', 'pr-review.md'))).toBe(true);
+		expect(existsSync(join(testDir, 'sops', 'ci-failure.md'))).toBe(true);
+		expect(existsSync(join(testDir, 'sops', 'linear-ticket.md'))).toBe(true);
+
+		// Engineering module should have added its transforms
+		expect(existsSync(join(testDir, 'transforms', 'engineering.yaml'))).toBe(true);
+
+		// Module should be registered in orgloop.yaml
+		const orgloopYaml = await readFile(join(testDir, 'orgloop.yaml'), 'utf-8');
+		expect(orgloopYaml).toContain('modules');
+		expect(orgloopYaml).toContain(ENGINEERING_MODULE);
+
+		// ── Step 3: doctor ─────────────────────────────────────────────────
+		// doctor exits 1 for degraded (warnings are expected, e.g. route graph)
+		const doctorOutput = cli('doctor --json', testDir, { allowFailure: true });
+		const doctorResult = JSON.parse(doctorOutput);
+
+		// Should have a project name
+		expect(doctorResult.project).toBe('test-org');
+
+		// Credential validation errors are expected with dummy tokens (validators
+		// make real HTTP calls). What matters is that ALL config checks pass —
+		// no schema errors, no broken transform refs, no bad route references.
+		const configChecks = doctorResult.checks.filter(
+			(c: { category: string }) => c.category === 'config',
+		);
+		expect(configChecks.length).toBeGreaterThan(0);
+		for (const check of configChecks) {
+			expect(check.status).toBe('ok');
+		}
+
+		// Credential env vars should all be present (not "missing")
+		const credentials = doctorResult.checks.filter(
+			(c: { category: string }) => c.category === 'credential',
+		);
+		for (const cred of credentials) {
+			// Status is either 'ok' (presence-only check) or 'error' (validator
+			// rejected dummy token). It should never be 'missing' since we set all vars.
+			expect(cred.status).not.toBe('missing');
+		}
+
+		// Module should be validated
+		const moduleCheck = doctorResult.checks.find(
+			(c: { name: string }) => c.name === 'module:engineering',
+		);
+		expect(moduleCheck).toBeDefined();
+		expect(moduleCheck.status).toBe('ok');
+
+		// ── Step 4: plan ──────────────────────────────────────────────────
+		const planOutput = cli('plan --json', testDir);
+		const planResult = JSON.parse(planOutput);
+
+		// Plan should have sources, actors, routes
+		expect(planResult.sources.length).toBeGreaterThan(0);
+		expect(planResult.actors.length).toBeGreaterThan(0);
+		expect(planResult.routes.length).toBeGreaterThan(0);
+
+		// Since no running state exists, all items should be "add"
+		for (const source of planResult.sources) {
+			expect(source.action).toBe('add');
+		}
+		for (const actor of planResult.actors) {
+			expect(actor.action).toBe('add');
+		}
+		for (const route of planResult.routes) {
+			expect(route.action).toBe('add');
+		}
+
+		// Should have engineering module routes
+		const routeNames = planResult.routes.map((r: { name: string }) => r.name);
+		expect(routeNames).toContain('engineering-pr-review');
+		expect(routeNames).toContain('engineering-ci-failure');
+
+		// Should have the expected sources
+		const sourceNames = planResult.sources.map((s: { name: string }) => s.name);
+		expect(sourceNames).toContain('github');
+
+		// Should have the expected actor
+		const actorNames = planResult.actors.map((a: { name: string }) => a.name);
+		expect(actorNames).toContain('openclaw-engineering-agent');
+
+		// Plan summary should show additions
+		expect(planResult.summary.add).toBeGreaterThan(0);
+	}, 60_000);
+
+	it('init scaffolds correct directory structure', async () => {
+		cli('init --no-interactive --name scaffold-test --connectors github --dir .', testDir);
+
+		// Verify all expected directories exist
+		const expectedDirs = ['connectors', 'routes', 'transforms', 'loggers', 'sops'];
+		for (const dir of expectedDirs) {
+			expect(existsSync(join(testDir, dir))).toBe(true);
+		}
+
+		// orgloop.yaml should reference the connector
+		const orgloopYaml = await readFile(join(testDir, 'orgloop.yaml'), 'utf-8');
+		expect(orgloopYaml).toContain('connectors/github.yaml');
+		expect(orgloopYaml).toContain('name: scaffold-test');
+	}, 30_000);
+
+	it('doctor reports errors when config is invalid', async () => {
+		cli('init --no-interactive --name error-test --connectors github --dir .', testDir);
+
+		// Remove the init-scaffolded example route so we don't get route graph warnings
+		// about the default source. Instead, let's create a route that references a
+		// non-existent source to generate an error.
+		const { writeFile } = await import('node:fs/promises');
+		await writeFile(
+			join(testDir, 'routes', 'broken.yaml'),
+			`apiVersion: orgloop/v1alpha1
+kind: RouteGroup
+
+routes:
+  - name: broken-route
+    when:
+      source: nonexistent-source
+      events:
+        - resource.changed
+    then:
+      actor: nonexistent-actor
+`,
+			'utf-8',
+		);
+
+		// doctor exits non-zero for degraded/error status
+		const doctorOutput = cli('doctor --json', testDir, { allowFailure: true });
+		const doctorResult = JSON.parse(doctorOutput);
+
+		// Should have route-graph warnings for the broken references
+		const routeGraphWarnings = doctorResult.checks.filter(
+			(c: { category: string }) => c.category === 'route-graph',
+		);
+
+		// The broken route references nonexistent source/actor, which should
+		// show up in validation or route graph warnings
+		expect(doctorResult.checks.length).toBeGreaterThan(0);
+	}, 30_000);
+
+	it('plan shows correct component count after module install', async () => {
+		// Init with full connector set
+		cli(
+			'init --no-interactive --name plan-test --connectors github,linear,openclaw,claude-code --dir .',
+			testDir,
+		);
+
+		// Add engineering module
+		cli(`add module engineering --path ${ENGINEERING_MODULE} --no-interactive`, testDir);
+
+		const planOutput = cli('plan --json', testDir);
+		const planResult = JSON.parse(planOutput);
+
+		// Engineering module provides 5 routes
+		// Plus the example route from init = 6 total
+		const moduleRoutes = planResult.routes.filter((r: { name: string }) =>
+			r.name.startsWith('engineering-'),
+		);
+		expect(moduleRoutes.length).toBe(5);
+
+		// Transforms should include engineering module transforms
+		expect(planResult.transforms.length).toBeGreaterThan(0);
+
+		// Loggers should be present (from init scaffold)
+		expect(planResult.loggers.length).toBeGreaterThan(0);
+	}, 60_000);
+});

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -8,12 +8,7 @@ import { access, chmod, cp, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path';
 import type { Command } from 'commander';
 import yaml from 'js-yaml';
-import {
-	expandModuleName,
-	expandModuleRoutes,
-	loadModuleManifest,
-	resolveModulePath,
-} from '../module-resolver.js';
+import { expandModuleRoutes, loadModuleManifest, resolveModulePath } from '../module-resolver.js';
 import * as output from '../output.js';
 
 async function fileExists(path: string): Promise<boolean> {
@@ -264,9 +259,6 @@ export function registerAddCommand(program: Command): void {
 					return;
 				}
 
-				// Expand short names (e.g. "engineering" → "@orgloop/module-engineering")
-				const fullName = opts.path ? name : expandModuleName(name);
-
 				// Resolve module path
 				const modulePath = opts.path ? resolve(cwd, opts.path) : resolveModulePath(name, cwd);
 
@@ -371,12 +363,10 @@ export function registerAddCommand(program: Command): void {
 					params: Record<string, string | number | boolean>;
 				}>;
 
-				const packageRef = opts.path ?? fullName;
-				const existing = modules.find(
-					(m) => m.package === packageRef || m.package === name || m.package === fullName,
-				);
+				const packageRef = opts.path ?? name;
+				const existing = modules.find((m) => m.package === packageRef || m.package === name);
 				if (existing) {
-					output.warn(`Module "${fullName}" is already installed. Updating parameters.`);
+					output.warn(`Module "${name}" is already installed. Updating parameters.`);
 					existing.params = params;
 				} else {
 					modules.push({

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,15 +1,80 @@
 #!/usr/bin/env bash
 # Pre-push hook: runs the full CI gate locally before pushing.
 # Install: git config core.hooksPath scripts
-set -euo pipefail
+set -uo pipefail
 
-echo "🔒 Pre-push gate: build → test → typecheck → lint"
-echo ""
+TMPDIR_HOOK=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_HOOK"' EXIT
 
-pnpm build
-pnpm test
-pnpm typecheck
-pnpm lint
+# Strip ANSI escape codes from a file
+strip_ansi() {
+  sed $'s/\x1b\\[[0-9;]*[a-zA-Z]//g; s/\x1b\\[?[0-9]*[a-zA-Z]//g' "$1"
+}
 
-echo ""
-echo "✅ All checks passed — pushing."
+run_gate() {
+  local name="$1"
+  shift
+  local out="$TMPDIR_HOOK/${name}.log"
+
+  if "$@" > "$out" 2>&1; then
+    local clean="$TMPDIR_HOOK/${name}.clean"
+    strip_ansi "$out" > "$clean"
+
+    local summary=""
+    case "$name" in
+      build)
+        local pkg_count
+        pkg_count=$(grep -oE 'Running build in [0-9]+ packages' "$clean" | grep -oE '[0-9]+' || true)
+        if [ -n "$pkg_count" ]; then
+          summary=" ($pkg_count packages)"
+        fi
+        ;;
+      test)
+        # Vitest streams progress, so each package has many "Tests" lines.
+        # The final line per package has total in parens: "Tests  N passed (N)"
+        # Use awk to keep only the last "Tests" line per turbo package prefix, then sum.
+        local total
+        total=$(awk '
+          /Tests.*passed/ {
+            # Extract package prefix (e.g., "@orgloop/sdk:test:")
+            match($0, /^@[^:]+:test:/)
+            pkg = substr($0, RSTART, RLENGTH)
+            # Extract the number in parentheses at end — the total test count
+            if (match($0, /\([0-9]+\)/)) {
+              n = substr($0, RSTART+1, RLENGTH-2)
+              last[pkg] = n
+            }
+          }
+          END {
+            total = 0
+            for (pkg in last) total += last[pkg]
+            print total
+          }
+        ' "$clean")
+        if [ "$total" -gt 0 ]; then
+          summary=" ($total passed)"
+        fi
+        ;;
+      lint)
+        local file_count
+        file_count=$(grep -oE 'Checked [0-9]+ files' "$clean" | grep -oE '[0-9]+' || true)
+        if [ -n "$file_count" ]; then
+          summary=" ($file_count files)"
+        fi
+        ;;
+    esac
+    printf '\033[32m✓\033[0m %s%s\n' "$name" "$summary"
+    return 0
+  else
+    printf '\033[31m✗\033[0m %s\n' "$name"
+    echo ""
+    echo "── $name output ──"
+    cat "$out"
+    return 1
+  fi
+}
+
+run_gate build pnpm build || exit 1
+run_gate test pnpm test || exit 1
+run_gate typecheck pnpm typecheck || exit 1
+run_gate lint pnpm lint || exit 1


### PR DESCRIPTION
## Summary

- **Fix engineering module packaging** — `transforms`, `connectors`, `loggers` were missing from the module's `files` field in package.json. After `orgloop add module engineering`, doctor reported "Transform 'my-notifications' not found" and "Transform 'dedup' not found" because those directories weren't included in the published package.
- **Graceful hook degradation (WQ-75)** — `orgloop hook` now exits 0 silently when the engine isn't running, instead of surfacing "fetch failed" errors in Claude Code on every session stop. Hooks are opportunistic.
- **Revert module name expansion** — Bare names like `engineering` now error with helpful guidance instead of silently expanding to `@orgloop/module-engineering`. Only fully qualified npm names and local paths supported. Removes monorepo fallback paths.
- **README e2e test** — 4 new tests validating the full onboarding flow (init → add module → doctor → plan). Would have caught the packaging bug pre-push.
- **Quiet pre-push hook (WQ-76)** — One-liner per gate on success, full output only on failure.

## Test plan

- [x] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` — all passing (835 tests)
- [x] README e2e test exercises full onboarding flow in temp dir
- [x] Manual test: init → add module → doctor in /tmp confirms 0 errors
- [x] Hook connection error detection covered by 6 new unit tests
- [x] Module name expansion rejection covered by updated module-e2e test

🤖 Generated with [Claude Code](https://claude.com/claude-code)