### PR TITLE
feat: connector health, rate limiting, .env support, and CLI hardening

### DIFF
--- a/loggers/console/src/format.ts
+++ b/loggers/console/src/format.ts
@@ -36,6 +36,9 @@ const PHASE_STYLES: Record<LogPhase, PhaseStyle> = {
 	'system.start': { icon: '\u25cf', color: MAGENTA }, // ●
 	'system.stop': { icon: '\u25cf', color: MAGENTA }, // ●
 	'system.error': { icon: '\u26a0', color: MAGENTA }, // ⚠
+	'source.circuit_open': { icon: '\u26a0', color: YELLOW }, // ⚠
+	'source.circuit_retry': { icon: '\u21bb', color: CYAN }, // ↻
+	'source.circuit_close': { icon: '\u2713', color: GREEN }, // ✓
 };
 
 /**
@@ -129,6 +132,9 @@ const PHASE_LEVELS: Record<LogPhase, number> = {
 	'system.start': 1, // info
 	'system.stop': 1, // info
 	'system.error': 3, // error
+	'source.circuit_open': 2, // warn
+	'source.circuit_retry': 1, // info
+	'source.circuit_close': 1, // info
 };
 
 const LEVEL_VALUES: Record<string, number> = {

--- a/loggers/otel/src/otel-logger.ts
+++ b/loggers/otel/src/otel-logger.ts
@@ -24,6 +24,9 @@ const PHASE_SEVERITY: Record<LogPhase, { text: string; number: number }> = {
 	'system.start': { text: 'INFO', number: 9 },
 	'system.stop': { text: 'INFO', number: 9 },
 	'system.error': { text: 'ERROR', number: 17 },
+	'source.circuit_open': { text: 'WARN', number: 13 },
+	'source.circuit_retry': { text: 'INFO', number: 9 },
+	'source.circuit_close': { text: 'INFO', number: 9 },
 };
 
 export interface OtelLoggerConfig {

--- a/loggers/syslog/src/syslog-logger.ts
+++ b/loggers/syslog/src/syslog-logger.ts
@@ -53,6 +53,9 @@ const PHASE_SEVERITY: Record<LogPhase, number> = {
 	'source.emit': 7, // Debug
 	'transform.start': 7, // Debug
 	'route.no_match': 7, // Debug
+	'source.circuit_open': 4, // Warning
+	'source.circuit_retry': 6, // Informational
+	'source.circuit_close': 6, // Informational
 };
 
 /** Get severity for a phase, with optional fatal upgrade */

--- a/packages/cli/src/__tests__/apply-doctor-gate.test.ts
+++ b/packages/cli/src/__tests__/apply-doctor-gate.test.ts
@@ -1,0 +1,102 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runDoctor } from '../commands/doctor.js';
+
+describe('apply doctor gate', () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), 'orgloop-apply-doctor-'));
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it('runDoctor returns ok when config is valid and env vars are set', async () => {
+		await writeFile(
+			join(tempDir, 'orgloop.yaml'),
+			`apiVersion: orgloop/v1alpha1
+kind: Project
+metadata:
+  name: test-ok
+`,
+		);
+
+		const result = await runDoctor(join(tempDir, 'orgloop.yaml'));
+		expect(result.status).toBe('ok');
+		expect(result.project).toBe('test-ok');
+	});
+
+	it('runDoctor returns error when config has invalid schema', async () => {
+		await writeFile(
+			join(tempDir, 'orgloop.yaml'),
+			`apiVersion: orgloop/v1alpha1
+kind: Wrong
+`,
+		);
+
+		const result = await runDoctor(join(tempDir, 'orgloop.yaml'));
+		expect(result.status).toBe('error');
+		const errorChecks = result.checks.filter((c) => c.status === 'error');
+		expect(errorChecks.length).toBeGreaterThan(0);
+	});
+
+	it('runDoctor returns degraded when env vars are missing', async () => {
+		await mkdir(join(tempDir, 'connectors'), { recursive: true });
+
+		await writeFile(
+			join(tempDir, 'orgloop.yaml'),
+			`apiVersion: orgloop/v1alpha1
+kind: Project
+metadata:
+  name: test-degraded
+connectors:
+  - connectors/test.yaml
+`,
+		);
+
+		await writeFile(
+			join(tempDir, 'connectors', 'test.yaml'),
+			`sources:
+  - id: test-source
+    connector: "@orgloop/connector-test"
+    config:
+      token: "\${APPLY_DOCTOR_GATE_MISSING_VAR}"
+`,
+		);
+
+		// Ensure the var is not set
+		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+		delete process.env.APPLY_DOCTOR_GATE_MISSING_VAR;
+
+		const result = await runDoctor(join(tempDir, 'orgloop.yaml'));
+		// Missing env vars result in degraded (missing credentials)
+		expect(['degraded', 'error']).toContain(result.status);
+		const missingChecks = result.checks.filter((c) => c.status === 'missing');
+		expect(missingChecks.length).toBeGreaterThan(0);
+	});
+
+	it('doctor gate allows --force to bypass errors', async () => {
+		// This test validates the concept: when force=true, doctor is skipped.
+		// We test this by confirming runDoctor would return error,
+		// showing that the gate would block without --force.
+		await writeFile(
+			join(tempDir, 'orgloop.yaml'),
+			`apiVersion: orgloop/v1alpha1
+kind: Wrong
+`,
+		);
+
+		const result = await runDoctor(join(tempDir, 'orgloop.yaml'));
+		expect(result.status).toBe('error');
+		// With --force, this error would be skipped and apply would proceed
+	});
+
+	it('printDoctorResult is exported and callable', async () => {
+		const { printDoctorResult } = await import('../commands/doctor.js');
+		expect(typeof printDoctorResult).toBe('function');
+	});
+});

--- a/packages/cli/src/__tests__/dotenv.test.ts
+++ b/packages/cli/src/__tests__/dotenv.test.ts
@@ -1,0 +1,152 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadDotEnv } from '../dotenv.js';
+
+describe('loadDotEnv', () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), 'orgloop-dotenv-test-'));
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it('loads KEY=VALUE pairs from .env next to orgloop.yaml', async () => {
+		await writeFile(
+			join(tempDir, 'orgloop.yaml'),
+			'apiVersion: orgloop/v1alpha1\nkind: Project\nmetadata:\n  name: test\n',
+		);
+		await writeFile(join(tempDir, '.env'), 'DOTENV_TEST_A=hello\nDOTENV_TEST_B=world\n');
+
+		// Ensure vars are not set
+		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+		delete process.env.DOTENV_TEST_A;
+		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+		delete process.env.DOTENV_TEST_B;
+
+		try {
+			const loaded = await loadDotEnv(join(tempDir, 'orgloop.yaml'));
+			expect(loaded).toContain('DOTENV_TEST_A');
+			expect(loaded).toContain('DOTENV_TEST_B');
+			expect(process.env.DOTENV_TEST_A).toBe('hello');
+			expect(process.env.DOTENV_TEST_B).toBe('world');
+		} finally {
+			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+			delete process.env.DOTENV_TEST_A;
+			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+			delete process.env.DOTENV_TEST_B;
+		}
+	});
+
+	it('skips comments and blank lines', async () => {
+		await writeFile(
+			join(tempDir, 'orgloop.yaml'),
+			'apiVersion: orgloop/v1alpha1\nkind: Project\nmetadata:\n  name: test\n',
+		);
+		await writeFile(
+			join(tempDir, '.env'),
+			'# This is a comment\n\nDOTENV_TEST_COMMENT=yes\n  # indented comment\n',
+		);
+
+		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+		delete process.env.DOTENV_TEST_COMMENT;
+
+		try {
+			const loaded = await loadDotEnv(join(tempDir, 'orgloop.yaml'));
+			expect(loaded).toEqual(['DOTENV_TEST_COMMENT']);
+			expect(process.env.DOTENV_TEST_COMMENT).toBe('yes');
+		} finally {
+			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+			delete process.env.DOTENV_TEST_COMMENT;
+		}
+	});
+
+	it('handles quoted values', async () => {
+		await writeFile(
+			join(tempDir, 'orgloop.yaml'),
+			'apiVersion: orgloop/v1alpha1\nkind: Project\nmetadata:\n  name: test\n',
+		);
+		await writeFile(
+			join(tempDir, '.env'),
+			'DOTENV_TEST_DQ="double quoted"\nDOTENV_TEST_SQ=\'single quoted\'\n',
+		);
+
+		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+		delete process.env.DOTENV_TEST_DQ;
+		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+		delete process.env.DOTENV_TEST_SQ;
+
+		try {
+			const loaded = await loadDotEnv(join(tempDir, 'orgloop.yaml'));
+			expect(loaded).toContain('DOTENV_TEST_DQ');
+			expect(loaded).toContain('DOTENV_TEST_SQ');
+			expect(process.env.DOTENV_TEST_DQ).toBe('double quoted');
+			expect(process.env.DOTENV_TEST_SQ).toBe('single quoted');
+		} finally {
+			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+			delete process.env.DOTENV_TEST_DQ;
+			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+			delete process.env.DOTENV_TEST_SQ;
+		}
+	});
+
+	it('shell env takes precedence over .env', async () => {
+		await writeFile(
+			join(tempDir, 'orgloop.yaml'),
+			'apiVersion: orgloop/v1alpha1\nkind: Project\nmetadata:\n  name: test\n',
+		);
+		await writeFile(join(tempDir, '.env'), 'DOTENV_TEST_EXISTING=from-dotenv\n');
+
+		process.env.DOTENV_TEST_EXISTING = 'from-shell';
+
+		try {
+			const loaded = await loadDotEnv(join(tempDir, 'orgloop.yaml'));
+			expect(loaded).not.toContain('DOTENV_TEST_EXISTING');
+			expect(process.env.DOTENV_TEST_EXISTING).toBe('from-shell');
+		} finally {
+			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+			delete process.env.DOTENV_TEST_EXISTING;
+		}
+	});
+
+	it('silently skips when no .env file exists', async () => {
+		await writeFile(
+			join(tempDir, 'orgloop.yaml'),
+			'apiVersion: orgloop/v1alpha1\nkind: Project\nmetadata:\n  name: test\n',
+		);
+
+		const loaded = await loadDotEnv(join(tempDir, 'orgloop.yaml'));
+		expect(loaded).toEqual([]);
+	});
+
+	it('returns only newly loaded vars (not ones already in env)', async () => {
+		await writeFile(
+			join(tempDir, 'orgloop.yaml'),
+			'apiVersion: orgloop/v1alpha1\nkind: Project\nmetadata:\n  name: test\n',
+		);
+		await writeFile(
+			join(tempDir, '.env'),
+			'DOTENV_TEST_NEW=new-value\nDOTENV_TEST_OLD=old-value\n',
+		);
+
+		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+		delete process.env.DOTENV_TEST_NEW;
+		process.env.DOTENV_TEST_OLD = 'already-set';
+
+		try {
+			const loaded = await loadDotEnv(join(tempDir, 'orgloop.yaml'));
+			expect(loaded).toEqual(['DOTENV_TEST_NEW']);
+			expect(process.env.DOTENV_TEST_NEW).toBe('new-value');
+			expect(process.env.DOTENV_TEST_OLD).toBe('already-set');
+		} finally {
+			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+			delete process.env.DOTENV_TEST_NEW;
+			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
+			delete process.env.DOTENV_TEST_OLD;
+		}
+	});
+});

--- a/packages/cli/src/__tests__/readme-e2e.test.ts
+++ b/packages/cli/src/__tests__/readme-e2e.test.ts
@@ -160,7 +160,7 @@ describe('README onboarding flow', () => {
 		expect(planResult.routes.length).toBeGreaterThan(0);
 
 		// All items should have a valid action
-		const validActions = ['add', 'unchanged', 'change'];
+		const validActions = ['add', 'unchanged', 'change', 'remove'];
 		for (const source of planResult.sources) {
 			expect(validActions).toContain(source.action);
 		}

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -284,7 +284,7 @@ export async function runDoctor(configPath: string, importFn?: ImportFn): Promis
 
 // ─── Display ─────────────────────────────────────────────────────────────────
 
-function printDoctorResult(result: DoctorResult): void {
+export function printDoctorResult(result: DoctorResult): void {
 	output.blank();
 	output.heading(`OrgLoop Doctor \u2014 ${result.project}`);
 

--- a/packages/cli/src/dotenv.ts
+++ b/packages/cli/src/dotenv.ts
@@ -1,0 +1,43 @@
+/**
+ * Native .env file support for the OrgLoop CLI.
+ *
+ * Loads KEY=VALUE pairs from a .env file in the project directory (next to orgloop.yaml).
+ * Shell environment variables take precedence over .env values (no overwrite).
+ */
+
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { parseEnvFile } from './commands/env.js';
+import { resolveConfigPath } from './config.js';
+
+/**
+ * Load a .env file from the same directory as orgloop.yaml.
+ * Sets process.env[KEY] only if not already set (shell env wins).
+ * Returns the list of variables that were loaded from .env.
+ * Silently skips if no .env file exists.
+ */
+export async function loadDotEnv(configPath?: string): Promise<string[]> {
+	const resolvedConfig = resolveConfigPath(configPath);
+	const configDir = dirname(resolvedConfig);
+	const dotenvPath = join(configDir, '.env');
+
+	let content: string;
+	try {
+		content = await readFile(dotenvPath, 'utf-8');
+	} catch {
+		// No .env file — not an error
+		return [];
+	}
+
+	const vars = parseEnvFile(content);
+	const loaded: string[] = [];
+
+	for (const [key, value] of vars) {
+		if (process.env[key] === undefined) {
+			process.env[key] = value;
+			loaded.push(key);
+		}
+	}
+
+	return loaded;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -27,6 +27,7 @@ import { registerStopCommand } from './commands/stop.js';
 import { registerTestCommand } from './commands/test.js';
 import { registerValidateCommand } from './commands/validate.js';
 import { registerVersionCommand } from './commands/version.js';
+import { loadDotEnv } from './dotenv.js';
 import { setJsonMode, setQuietMode, setVerboseMode } from './output.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -50,17 +51,18 @@ async function main(): Promise<void> {
 	program
 		.name('orgloop')
 		.description('OrgLoop — Organization as Code runtime')
-		.version(version, '-V, --version-flag', 'Print version number')
+		.version(version, '-V, --version', 'Print version number')
 		.option('-c, --config <path>', 'Path to orgloop.yaml')
 		.option('-w, --workspace <name>', 'Workspace name', 'default')
 		.option('-v, --verbose', 'Verbose output')
 		.option('--json', 'Output as JSON (for scripting)')
 		.option('--quiet', 'Errors only')
-		.hook('preAction', (thisCommand) => {
+		.hook('preAction', async (thisCommand) => {
 			const opts = thisCommand.opts();
 			if (opts.json) setJsonMode(true);
 			if (opts.verbose) setVerboseMode(true);
 			if (opts.quiet) setQuietMode(true);
+			await loadDotEnv(opts.config);
 		});
 
 	// Register all commands

--- a/packages/core/src/__tests__/health-tracking.test.ts
+++ b/packages/core/src/__tests__/health-tracking.test.ts
@@ -1,0 +1,479 @@
+import { MockActor, MockSource, createTestEvent } from '@orgloop/sdk';
+import type { OrgLoopConfig, SourceHealthState } from '@orgloop/sdk';
+import { describe, expect, it, vi } from 'vitest';
+import { OrgLoop } from '../engine.js';
+
+function getHealth(engine: OrgLoop, sourceId: string): SourceHealthState {
+	const h = engine.health().find((s) => s.sourceId === sourceId);
+	if (!h) throw new Error(`No health state for ${sourceId}`);
+	return h;
+}
+
+function makeConfig(overrides?: Partial<OrgLoopConfig>): OrgLoopConfig {
+	return {
+		project: { name: 'health-test' },
+		sources: [
+			{
+				id: 'test-source',
+				connector: 'mock',
+				config: {},
+				poll: { interval: '5m' },
+			},
+		],
+		actors: [
+			{
+				id: 'test-actor',
+				connector: 'mock',
+				config: {},
+			},
+		],
+		routes: [
+			{
+				name: 'test-route',
+				when: {
+					source: 'test-source',
+					events: ['resource.changed'],
+				},
+				then: {
+					actor: 'test-actor',
+				},
+			},
+		],
+		transforms: [],
+		loggers: [],
+		...overrides,
+	};
+}
+
+describe('Source health tracking', () => {
+	it('initializes health state for all sources on start', async () => {
+		const source = new MockSource('test-source');
+		const actor = new MockActor('test-actor');
+
+		const engine = new OrgLoop(makeConfig(), {
+			sources: new Map([['test-source', source]]),
+			actors: new Map([['test-actor', actor]]),
+		});
+
+		await engine.start();
+
+		const health = engine.health();
+		expect(health).toHaveLength(1);
+		expect(health[0].sourceId).toBe('test-source');
+		expect(health[0].status).toBe('healthy');
+		expect(health[0].consecutiveErrors).toBe(0);
+		expect(health[0].circuitOpen).toBe(false);
+		expect(health[0].totalEventsEmitted).toBe(0);
+
+		await engine.stop();
+	});
+
+	it('tracks successful polls and event counts', async () => {
+		const source = new MockSource('test-source');
+		const actor = new MockActor('test-actor');
+
+		const engine = new OrgLoop(makeConfig(), {
+			sources: new Map([['test-source', source]]),
+			actors: new Map([['test-actor', actor]]),
+		});
+
+		await engine.start();
+
+		// Inject events (simulates what poll does after processing)
+		const event1 = createTestEvent({ source: 'test-source', type: 'resource.changed' });
+		const event2 = createTestEvent({ source: 'test-source', type: 'resource.changed' });
+		source.addEvents(event1, event2);
+
+		// Trigger a poll manually by accessing private method
+		// biome-ignore lint: accessing private for test
+		await (engine as any).pollSource('test-source');
+
+		const h = getHealth(engine, 'test-source');
+		expect(h.status).toBe('healthy');
+		expect(h.totalEventsEmitted).toBe(2);
+		expect(h.lastSuccessfulPoll).not.toBeNull();
+		expect(h.consecutiveErrors).toBe(0);
+		expect(h.lastError).toBeNull();
+
+		await engine.stop();
+	});
+
+	it('tracks consecutive errors on poll failure', async () => {
+		const source = new MockSource('test-source');
+		const actor = new MockActor('test-actor');
+
+		// Make poll throw (also affects the initial scheduler poll)
+		vi.spyOn(source, 'poll').mockRejectedValue(new Error('403 Forbidden'));
+
+		const engine = new OrgLoop(makeConfig(), {
+			sources: new Map([['test-source', source]]),
+			actors: new Map([['test-actor', actor]]),
+		});
+
+		// Suppress error events
+		engine.on('error', () => {});
+
+		await engine.start();
+		// Scheduler fires first poll automatically — wait for it
+		await vi.waitFor(() => {
+			const h = getHealth(engine, 'test-source');
+			expect(h.consecutiveErrors).toBeGreaterThanOrEqual(1);
+		});
+
+		let h = getHealth(engine, 'test-source');
+		const errorsAfterStart = h.consecutiveErrors;
+		expect(h.status).toBe('degraded');
+		expect(h.lastError).toBe('403 Forbidden');
+
+		// Another failure
+		// biome-ignore lint: accessing private for test
+		await (engine as any).pollSource('test-source');
+
+		h = getHealth(engine, 'test-source');
+		expect(h.consecutiveErrors).toBe(errorsAfterStart + 1);
+
+		await engine.stop();
+	});
+
+	it('resets error count on successful poll after failures', async () => {
+		const source = new MockSource('test-source');
+		const actor = new MockActor('test-actor');
+		const pollSpy = vi.spyOn(source, 'poll');
+
+		// First two polls fail (initial scheduler poll + one manual)
+		pollSpy.mockRejectedValueOnce(new Error('network error'));
+		pollSpy.mockRejectedValueOnce(new Error('network error'));
+
+		const engine = new OrgLoop(makeConfig(), {
+			sources: new Map([['test-source', source]]),
+			actors: new Map([['test-actor', actor]]),
+		});
+
+		engine.on('error', () => {});
+
+		await engine.start();
+		// Wait for initial scheduler poll
+		await vi.waitFor(() => {
+			const h = getHealth(engine, 'test-source');
+			expect(h.consecutiveErrors).toBeGreaterThanOrEqual(1);
+		});
+
+		// Trigger another failed poll
+		// biome-ignore lint: accessing private for test
+		await (engine as any).pollSource('test-source');
+
+		let h = getHealth(engine, 'test-source');
+		expect(h.consecutiveErrors).toBeGreaterThanOrEqual(2);
+		expect(h.status).toBe('degraded');
+
+		// Restore normal behavior — next poll succeeds
+		pollSpy.mockRestore();
+
+		// biome-ignore lint: accessing private for test
+		await (engine as any).pollSource('test-source');
+
+		h = getHealth(engine, 'test-source');
+		expect(h.consecutiveErrors).toBe(0);
+		expect(h.status).toBe('healthy');
+		expect(h.lastError).toBeNull();
+		expect(h.lastSuccessfulPoll).not.toBeNull();
+
+		await engine.stop();
+	});
+
+	it('health data is included in engine status', async () => {
+		const source = new MockSource('test-source');
+		const actor = new MockActor('test-actor');
+
+		const engine = new OrgLoop(makeConfig(), {
+			sources: new Map([['test-source', source]]),
+			actors: new Map([['test-actor', actor]]),
+		});
+
+		await engine.start();
+
+		const status = engine.status();
+		expect(status.health).toBeDefined();
+		expect(status.health).toHaveLength(1);
+		expect(status.health?.[0].sourceId).toBe('test-source');
+
+		await engine.stop();
+	});
+
+	it('tracks health for multiple sources independently', async () => {
+		const source1 = new MockSource('source-1');
+		const source2 = new MockSource('source-2');
+		const actor = new MockActor('test-actor');
+
+		vi.spyOn(source1, 'poll').mockRejectedValue(new Error('auth failed'));
+
+		const config = makeConfig({
+			sources: [
+				{ id: 'source-1', connector: 'mock', config: {}, poll: { interval: '5m' } },
+				{ id: 'source-2', connector: 'mock', config: {}, poll: { interval: '5m' } },
+			],
+			routes: [
+				{
+					name: 'route-1',
+					when: { source: 'source-1', events: ['resource.changed'] },
+					then: { actor: 'test-actor' },
+				},
+				{
+					name: 'route-2',
+					when: { source: 'source-2', events: ['resource.changed'] },
+					then: { actor: 'test-actor' },
+				},
+			],
+		});
+
+		const engine = new OrgLoop(config, {
+			sources: new Map([
+				['source-1', source1],
+				['source-2', source2],
+			]),
+			actors: new Map([['test-actor', actor]]),
+		});
+
+		engine.on('error', () => {});
+
+		await engine.start();
+		// Wait for initial scheduler polls to complete
+		await vi.waitFor(() => {
+			const h1 = getHealth(engine, 'source-1');
+			expect(h1.consecutiveErrors).toBeGreaterThanOrEqual(1);
+		});
+
+		const h1 = getHealth(engine, 'source-1');
+		const h2 = getHealth(engine, 'source-2');
+
+		expect(h1.status).toBe('degraded');
+		expect(h1.consecutiveErrors).toBeGreaterThanOrEqual(1);
+		expect(h2.status).toBe('healthy');
+		expect(h2.consecutiveErrors).toBe(0);
+
+		await engine.stop();
+	});
+});
+
+describe('Circuit breaker', () => {
+	it('opens circuit after N consecutive failures (default: 5)', async () => {
+		const source = new MockSource('test-source');
+		const actor = new MockActor('test-actor');
+
+		vi.spyOn(source, 'poll').mockRejectedValue(new Error('403 Forbidden'));
+
+		const engine = new OrgLoop(makeConfig(), {
+			sources: new Map([['test-source', source]]),
+			actors: new Map([['test-actor', actor]]),
+		});
+
+		engine.on('error', () => {});
+
+		await engine.start();
+
+		// 5 consecutive failures
+		for (let i = 0; i < 5; i++) {
+			// biome-ignore lint: accessing private for test
+			await (engine as any).pollSource('test-source');
+		}
+
+		const h = getHealth(engine, 'test-source');
+		expect(h.status).toBe('unhealthy');
+		expect(h.circuitOpen).toBe(true);
+		expect(h.consecutiveErrors).toBe(5);
+
+		await engine.stop();
+	});
+
+	it('respects custom failure threshold', async () => {
+		const source = new MockSource('test-source');
+		const actor = new MockActor('test-actor');
+
+		vi.spyOn(source, 'poll').mockRejectedValue(new Error('timeout'));
+
+		// Set threshold to 4 to account for the initial scheduler poll
+		const engine = new OrgLoop(makeConfig(), {
+			sources: new Map([['test-source', source]]),
+			actors: new Map([['test-actor', actor]]),
+			circuitBreaker: { failureThreshold: 4 },
+		});
+
+		engine.on('error', () => {});
+
+		await engine.start();
+		// Wait for initial scheduler poll
+		await vi.waitFor(() => {
+			const h = getHealth(engine, 'test-source');
+			expect(h.consecutiveErrors).toBeGreaterThanOrEqual(1);
+		});
+
+		// 2 more manual failures (total: 3 with scheduler poll = under threshold of 4)
+		// biome-ignore lint: accessing private for test
+		await (engine as any).pollSource('test-source');
+		// biome-ignore lint: accessing private for test
+		await (engine as any).pollSource('test-source');
+
+		let h = getHealth(engine, 'test-source');
+		expect(h.circuitOpen).toBe(false);
+		expect(h.status).toBe('degraded');
+
+		// One more — reaches threshold of 4
+		// biome-ignore lint: accessing private for test
+		await (engine as any).pollSource('test-source');
+
+		h = getHealth(engine, 'test-source');
+		expect(h.circuitOpen).toBe(true);
+		expect(h.status).toBe('unhealthy');
+
+		await engine.stop();
+	});
+
+	it('skips polling when circuit is open', async () => {
+		const source = new MockSource('test-source');
+		const actor = new MockActor('test-actor');
+		const pollSpy = vi.spyOn(source, 'poll').mockRejectedValue(new Error('error'));
+
+		const engine = new OrgLoop(makeConfig(), {
+			sources: new Map([['test-source', source]]),
+			actors: new Map([['test-actor', actor]]),
+			circuitBreaker: { failureThreshold: 2 },
+		});
+
+		engine.on('error', () => {});
+
+		await engine.start();
+
+		// Open circuit (2 failures)
+		// biome-ignore lint: accessing private for test
+		await (engine as any).pollSource('test-source');
+		// biome-ignore lint: accessing private for test
+		await (engine as any).pollSource('test-source');
+
+		expect(getHealth(engine, 'test-source').circuitOpen).toBe(true);
+
+		const callCount = pollSpy.mock.calls.length;
+
+		// Try polling again — should be skipped
+		// biome-ignore lint: accessing private for test
+		await (engine as any).pollSource('test-source');
+
+		// poll() should NOT have been called again
+		expect(pollSpy.mock.calls.length).toBe(callCount);
+
+		await engine.stop();
+	});
+
+	it('retries after backoff period and recovers on success', async () => {
+		vi.useFakeTimers();
+
+		const source = new MockSource('test-source');
+		const actor = new MockActor('test-actor');
+		const pollSpy = vi.spyOn(source, 'poll');
+
+		// First 2 polls fail
+		pollSpy.mockRejectedValueOnce(new Error('error'));
+		pollSpy.mockRejectedValueOnce(new Error('error'));
+		// Recovery poll succeeds
+		pollSpy.mockResolvedValueOnce({ events: [], checkpoint: 'ok' });
+
+		const engine = new OrgLoop(makeConfig(), {
+			sources: new Map([['test-source', source]]),
+			actors: new Map([['test-actor', actor]]),
+			circuitBreaker: { failureThreshold: 2, retryAfterMs: 5000 },
+		});
+
+		engine.on('error', () => {});
+
+		await engine.start();
+
+		// Trigger 2 failures to open circuit
+		// biome-ignore lint: accessing private for test
+		await (engine as any).pollSource('test-source');
+		// biome-ignore lint: accessing private for test
+		await (engine as any).pollSource('test-source');
+
+		expect(getHealth(engine, 'test-source').circuitOpen).toBe(true);
+
+		// Advance past backoff
+		await vi.advanceTimersByTimeAsync(5000);
+
+		// After retry, circuit should be closed
+		const h = getHealth(engine, 'test-source');
+		expect(h.circuitOpen).toBe(false);
+		expect(h.consecutiveErrors).toBe(0);
+		expect(h.status).toBe('healthy');
+
+		vi.useRealTimers();
+		await engine.stop();
+	});
+
+	it('stays in circuit-open state if retry fails', async () => {
+		vi.useFakeTimers();
+
+		const source = new MockSource('test-source');
+		const actor = new MockActor('test-actor');
+
+		vi.spyOn(source, 'poll').mockRejectedValue(new Error('still broken'));
+
+		const engine = new OrgLoop(makeConfig(), {
+			sources: new Map([['test-source', source]]),
+			actors: new Map([['test-actor', actor]]),
+			circuitBreaker: { failureThreshold: 2, retryAfterMs: 5000 },
+		});
+
+		engine.on('error', () => {});
+
+		await engine.start();
+
+		// Open circuit
+		// biome-ignore lint: accessing private for test
+		await (engine as any).pollSource('test-source');
+		// biome-ignore lint: accessing private for test
+		await (engine as any).pollSource('test-source');
+
+		expect(getHealth(engine, 'test-source').circuitOpen).toBe(true);
+
+		// Advance past backoff — retry will also fail
+		await vi.advanceTimersByTimeAsync(5000);
+
+		const h = getHealth(engine, 'test-source');
+		expect(h.circuitOpen).toBe(true);
+		expect(h.status).toBe('unhealthy');
+
+		vi.useRealTimers();
+		await engine.stop();
+	});
+
+	it('cleans up retry timers on stop', async () => {
+		vi.useFakeTimers();
+
+		const source = new MockSource('test-source');
+		const actor = new MockActor('test-actor');
+
+		vi.spyOn(source, 'poll').mockRejectedValue(new Error('error'));
+
+		const engine = new OrgLoop(makeConfig(), {
+			sources: new Map([['test-source', source]]),
+			actors: new Map([['test-actor', actor]]),
+			circuitBreaker: { failureThreshold: 2, retryAfterMs: 60000 },
+		});
+
+		engine.on('error', () => {});
+
+		await engine.start();
+
+		// Open circuit
+		// biome-ignore lint: accessing private for test
+		await (engine as any).pollSource('test-source');
+		// biome-ignore lint: accessing private for test
+		await (engine as any).pollSource('test-source');
+
+		// Stop engine — should clear timers without error
+		await engine.stop();
+
+		// Advancing time should not cause errors
+		await vi.advanceTimersByTimeAsync(60000);
+
+		vi.useRealTimers();
+	});
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,7 @@
 
 // Main engine
 export { OrgLoop } from './engine.js';
-export type { OrgLoopOptions, EngineStatus } from './engine.js';
+export type { OrgLoopOptions, EngineStatus, SourceCircuitBreakerOptions } from './engine.js';
 
 // Config loading
 export { loadConfig, buildConfig } from './schema.js';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -35,6 +35,8 @@ export type {
 	EventHandler,
 	Subscription,
 	DurationString,
+	SourceHealthStatus,
+	SourceHealthState,
 } from './types.js';
 
 export { parseDuration } from './types.js';

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -188,6 +188,9 @@ export interface LoggerDefinition {
 /** Pipeline phase identifiers */
 export type LogPhase =
 	| 'source.emit'
+	| 'source.circuit_open'
+	| 'source.circuit_retry'
+	| 'source.circuit_close'
 	| 'transform.start'
 	| 'transform.pass'
 	| 'transform.drop'
@@ -322,6 +325,31 @@ export interface ActorInstanceConfig {
 	connector: string;
 	/** Connector-specific config */
 	config: Record<string, unknown>;
+}
+
+// ─── Source Health ─────────────────────────────────────────────────────────────
+
+/** Health status of a source connector */
+export type SourceHealthStatus = 'healthy' | 'degraded' | 'unhealthy';
+
+/** Per-source health state tracked by the engine */
+export interface SourceHealthState {
+	/** Source connector ID */
+	sourceId: string;
+	/** Current health status */
+	status: SourceHealthStatus;
+	/** Timestamp of last successful poll (ISO 8601) */
+	lastSuccessfulPoll: string | null;
+	/** Timestamp of last poll attempt (ISO 8601) */
+	lastPollAttempt: string | null;
+	/** Number of consecutive poll failures */
+	consecutiveErrors: number;
+	/** Last error message (null if last poll succeeded) */
+	lastError: string | null;
+	/** Total events emitted by this source */
+	totalEventsEmitted: number;
+	/** Whether the circuit breaker is open (polling paused) */
+	circuitOpen: boolean;
 }
 
 // ─── Event Bus ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **WQ-84: GitHub connector rate limiting** (CRITICAL) — Default 7-day lookback window instead of epoch crawl, `X-RateLimit-Remaining` header awareness with backoff, pagination early termination, partial checkpoint persistence on rate limit
- **WQ-79: Connector health visibility** — Per-source health state tracking (healthy/degraded/unhealthy), circuit breaker (opens after 5 consecutive failures, retries after backoff), `orgloop status` shows per-connector health columns, health state persisted to state file
- **WQ-75: Hook error resilience** — `orgloop hook` exits 0 gracefully when engine isn't running instead of surfacing errors to Claude Code on every session stop
- **WQ-83: Native .env file support** — Auto-loads `.env` from project directory via Commander `preAction` hook, shell env takes precedence, works for all CLI commands
- **WQ-80: Gate apply on doctor** — `orgloop apply` runs full doctor pre-flight before launching daemon, blocks on errors, `--force` flag to bypass
- **WQ-78: --version flag** — `orgloop --version` / `-V` reads from package.json

## Test plan

- [x] All 871 tests passing (34 new tests added across 4 test files)
- [x] Build clean (19 packages)
- [x] Typecheck clean
- [x] Lint clean (131 files, 0 errors)
- [x] Manual: `orgloop apply` with missing env vars → doctor gate blocks with actionable error
- [x] Manual: `orgloop apply --force` → bypasses doctor, fails at config resolution as expected
- [x] Manual: `orgloop --version` → outputs `0.1.4`
- [x] Manual: `orgloop hook claude-code-stop` with engine down → exits 0 silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)