### PR TITLE
fix(build): clean stale tsbuildinfo, exclude tests from tsconfigs

### DIFF
--- a/connectors/claude-code/tsconfig.json
+++ b/connectors/claude-code/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": "src"
   },
   "include": ["src"],
+  "exclude": ["src/__tests__"],
   "references": [
     { "path": "../../packages/sdk" }
   ]

--- a/connectors/gog/tsconfig.json
+++ b/connectors/gog/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": "src"
   },
   "include": ["src"],
+  "exclude": ["src/__tests__"],
   "references": [
     { "path": "../../packages/sdk" }
   ]

--- a/connectors/linear/tsconfig.json
+++ b/connectors/linear/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": "src"
   },
   "include": ["src"],
+  "exclude": ["src/__tests__"],
   "references": [
     { "path": "../../packages/sdk" }
   ]

--- a/connectors/openclaw/tsconfig.json
+++ b/connectors/openclaw/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": "src"
   },
   "include": ["src"],
+  "exclude": ["src/__tests__"],
   "references": [
     { "path": "../../packages/sdk" }
   ]

--- a/connectors/webhook/tsconfig.json
+++ b/connectors/webhook/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": "src"
   },
   "include": ["src"],
+  "exclude": ["src/__tests__"],
   "references": [
     { "path": "../../packages/sdk" }
   ]

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": "src"
   },
   "include": ["src"],
+  "exclude": ["src/__tests__"],
   "references": [
     { "path": "../sdk" }
   ]


### PR DESCRIPTION
## Summary

- **Root cause**: The SDK uses `"composite": true` (incremental compilation). `pnpm clean` removed `dist/` but left `tsconfig.tsbuildinfo`, so subsequent `tsc` runs thought nothing changed and emitted zero files. Every downstream package then failed with `Cannot find module '@orgloop/sdk'`.
- SDK `clean` script now removes `tsconfig.tsbuildinfo` alongside `dist/`
- Added missing `"exclude": ["src/__tests__"]` to 6 packages (gog, linear, openclaw, webhook, claude-code, server) for consistency with the rest of the monorepo

## Why CI passed but local builds failed

CI starts from a fresh `actions/checkout` — no `.tsbuildinfo` files exist. Locally, after a `pnpm clean` && `pnpm build` cycle, the stale `.tsbuildinfo` prevented the SDK from re-emitting its type declarations.

## Test plan

- [x] `pnpm build` passes (20 packages)
- [x] `pnpm test` passes (962 tests)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] Verified `pnpm clean` now removes `tsconfig.tsbuildinfo` from SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)