### PR TITLE
feat(core): WQ-92 — strip YAML front matter from prompt files

### DIFF
--- a/packages/core/src/__tests__/prompt.test.ts
+++ b/packages/core/src/__tests__/prompt.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest';
+import { stripFrontMatter } from '../prompt.js';
+
+describe('stripFrontMatter', () => {
+	it('strips YAML front matter and returns parsed metadata', () => {
+		const input = `---
+title: Review SOP
+priority: high
+---
+You are a code reviewer.`;
+
+		const result = stripFrontMatter(input);
+		expect(result.content).toBe('You are a code reviewer.');
+		expect(result.metadata).toEqual({ title: 'Review SOP', priority: 'high' });
+	});
+
+	it('returns content unchanged when no front matter present', () => {
+		const input = 'Just a plain prompt file.\nNo front matter here.';
+
+		const result = stripFrontMatter(input);
+		expect(result.content).toBe(input);
+		expect(result.metadata).toBeNull();
+	});
+
+	it('handles various YAML types (strings, numbers, booleans, arrays)', () => {
+		const input = `---
+name: test
+version: 3
+enabled: true
+tags:
+  - review
+  - sop
+---
+Content here.`;
+
+		const result = stripFrontMatter(input);
+		expect(result.content).toBe('Content here.');
+		expect(result.metadata).toEqual({
+			name: 'test',
+			version: 3,
+			enabled: true,
+			tags: ['review', 'sop'],
+		});
+	});
+
+	it('handles empty front matter block', () => {
+		const input = `---
+---
+Content after empty front matter.`;
+
+		const result = stripFrontMatter(input);
+		expect(result.content).toBe('Content after empty front matter.');
+		// js-yaml.load('') returns undefined, so metadata should be null
+		expect(result.metadata).toBeNull();
+	});
+
+	it('does not strip --- that appears mid-document (horizontal rules)', () => {
+		const input = `Some text above.
+
+---
+
+Some text below.`;
+
+		const result = stripFrontMatter(input);
+		expect(result.content).toBe(input);
+		expect(result.metadata).toBeNull();
+	});
+
+	it('requires front matter to start at line 1', () => {
+		const input = `
+---
+title: Not front matter
+---
+Content.`;
+
+		const result = stripFrontMatter(input);
+		// Leading newline means --- is not at position 0
+		expect(result.content).toBe(input);
+		expect(result.metadata).toBeNull();
+	});
+
+	it('returns empty string content and null metadata for empty file', () => {
+		const result = stripFrontMatter('');
+		expect(result.content).toBe('');
+		expect(result.metadata).toBeNull();
+	});
+
+	it('handles file with only front matter and no content after', () => {
+		const input = `---
+title: Metadata only
+---
+`;
+
+		const result = stripFrontMatter(input);
+		expect(result.content).toBe('');
+		expect(result.metadata).toEqual({ title: 'Metadata only' });
+	});
+
+	it('handles front matter with no trailing newline after closing delimiter', () => {
+		const input = `---
+title: No trailing newline
+---
+Content starts here.`;
+
+		const result = stripFrontMatter(input);
+		expect(result.content).toBe('Content starts here.');
+		expect(result.metadata).toEqual({ title: 'No trailing newline' });
+	});
+
+	it('handles trailing whitespace on delimiter lines', () => {
+		const input = `---
+title: Whitespace delimiters
+---
+Content.`;
+
+		const result = stripFrontMatter(input);
+		expect(result.content).toBe('Content.');
+		expect(result.metadata).toEqual({ title: 'Whitespace delimiters' });
+	});
+
+	it('returns null metadata for invalid YAML in front matter', () => {
+		const input = `---
+: invalid: yaml: [
+---
+Content after bad YAML.`;
+
+		const result = stripFrontMatter(input);
+		expect(result.content).toBe('Content after bad YAML.');
+		expect(result.metadata).toBeNull();
+	});
+
+	it('returns null metadata when YAML parses to a non-object (scalar)', () => {
+		const input = `---
+just a string
+---
+Content.`;
+
+		const result = stripFrontMatter(input);
+		expect(result.content).toBe('Content.');
+		expect(result.metadata).toBeNull();
+	});
+
+	it('returns null metadata when YAML parses to an array', () => {
+		const input = `---
+- item1
+- item2
+---
+Content.`;
+
+		const result = stripFrontMatter(input);
+		expect(result.content).toBe('Content.');
+		expect(result.metadata).toBeNull();
+	});
+
+	it('preserves multi-line content after front matter', () => {
+		const input = `---
+role: reviewer
+---
+Line 1.
+
+Line 3 after blank.
+
+## Section
+
+More content.`;
+
+		const result = stripFrontMatter(input);
+		expect(result.content).toBe('Line 1.\n\nLine 3 after blank.\n\n## Section\n\nMore content.');
+		expect(result.metadata).toEqual({ role: 'reviewer' });
+	});
+
+	it('handles multi-line YAML values', () => {
+		const input = [
+			'---',
+			'description: |',
+			'  This is a multi-line',
+			'  description value.',
+			'title: Test',
+			'---',
+			'Body content',
+		].join('\n');
+
+		const result = stripFrontMatter(input);
+		expect(result.content).toBe('Body content');
+		expect(result.metadata).not.toBeNull();
+		expect(result.metadata?.title).toBe('Test');
+		expect((result.metadata?.description as string).trim()).toBe(
+			'This is a multi-line\ndescription value.',
+		);
+	});
+
+	it('does not treat --- as front matter when text appears before it', () => {
+		const input = 'Some text\n---\ntitle: x\n---\ncontent';
+
+		const result = stripFrontMatter(input);
+		expect(result.content).toBe(input);
+		expect(result.metadata).toBeNull();
+	});
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,6 +60,10 @@ export type { RuntimeControl } from './http.js';
 export { Runtime } from './runtime.js';
 export type { RuntimeOptions, LoadModuleOptions } from './runtime.js';
 
+// Prompt utilities
+export { stripFrontMatter } from './prompt.js';
+export type { StripFrontMatterResult } from './prompt.js';
+
 // Module system
 export { ModuleInstance } from './module-instance.js';
 export type { ModuleConfig, ModuleContext } from './module-instance.js';

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -1,0 +1,46 @@
+/**
+ * Prompt file utilities — front matter parsing for launch prompts.
+ */
+
+import yaml from 'js-yaml';
+
+export interface StripFrontMatterResult {
+	/** Prompt content with front matter removed */
+	content: string;
+	/** Parsed YAML front matter metadata, or null if none found */
+	metadata: Record<string, unknown> | null;
+}
+
+const FRONT_MATTER_RE = /^---[ \t]*\n([\s\S]*?\n)?---[ \t]*\n?/;
+
+/**
+ * Strip YAML front matter from prompt file content.
+ *
+ * Front matter must start at line 1 with `---`, contain YAML,
+ * and end with `---` on its own line. Everything after the closing
+ * delimiter is returned as the prompt content.
+ *
+ * Files without front matter are returned as-is with null metadata.
+ */
+export function stripFrontMatter(raw: string): StripFrontMatterResult {
+	const match = FRONT_MATTER_RE.exec(raw);
+	if (!match) {
+		return { content: raw, metadata: null };
+	}
+
+	const frontMatterYaml = (match[1] ?? '').replace(/\n$/, '');
+	const content = raw.slice(match[0].length);
+
+	let metadata: Record<string, unknown> | null = null;
+	try {
+		const parsed = yaml.load(frontMatterYaml);
+		if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+			metadata = parsed as Record<string, unknown>;
+		}
+	} catch {
+		// Invalid YAML in front matter — treat as no metadata
+		metadata = null;
+	}
+
+	return { content, metadata };
+}

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -26,6 +26,7 @@ import type { RuntimeControl } from './http.js';
 import { LoggerManager } from './logger.js';
 import type { ModuleConfig, ModuleContext } from './module-instance.js';
 import { ModuleInstance } from './module-instance.js';
+import { stripFrontMatter } from './prompt.js';
 import { ModuleRegistry } from './registry.js';
 import { matchRoutes } from './router.js';
 import { Scheduler } from './scheduler.js';
@@ -438,8 +439,10 @@ class Runtime extends EventEmitter implements RuntimeControl {
 			if (route.with?.prompt_file) {
 				try {
 					const promptContent = await readFile(route.with.prompt_file, 'utf-8');
-					deliveryConfig.launch_prompt = promptContent;
+					const { content: strippedContent, metadata } = stripFrontMatter(promptContent);
+					deliveryConfig.launch_prompt = strippedContent;
 					deliveryConfig.launch_prompt_file = route.with.prompt_file;
+					deliveryConfig.launch_prompt_meta = metadata;
 				} catch {
 					// Non-fatal: log but continue delivery
 				}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -155,10 +155,12 @@ export interface RouteWith {
 export interface RouteDeliveryConfig {
 	/** Actor-specific config from route's then.config */
 	[key: string]: unknown;
-	/** Resolved launch prompt text (from route's with.prompt_file) */
+	/** Resolved launch prompt text (from route's with.prompt_file, front matter stripped) */
 	launch_prompt?: string;
 	/** Original prompt file path (for reference/logging) */
 	launch_prompt_file?: string;
+	/** Parsed front matter metadata from prompt file, or null if none */
+	launch_prompt_meta?: Record<string, unknown> | null;
 }
 
 /** Error policy for transforms — controls behavior when a transform throws */


### PR DESCRIPTION
## Summary

- Route prompt files now support YAML front matter (`---` delimiters) — front matter is stripped before delivery so authors can add notes, metadata, or change history without it leaking into the prompt content
- Parsed front matter metadata is attached as `launch_prompt_meta` on `RouteDeliveryConfig` for future use
- New `stripFrontMatter()` utility in `packages/core/src/prompt.ts` with graceful fallback for invalid/missing front matter

## Changes

| File | What |
|------|------|
| `packages/core/src/prompt.ts` | New `stripFrontMatter()` — regex-based front matter detection, `js-yaml` parsing |
| `packages/core/src/runtime.ts` | Wired stripping into prompt file loading path |
| `packages/core/src/index.ts` | Exported new function + type |
| `packages/sdk/src/types.ts` | Added `launch_prompt_meta` to `RouteDeliveryConfig` |
| `packages/core/src/__tests__/prompt.test.ts` | 16 unit tests |
| `packages/core/src/__tests__/engine-integration.test.ts` | 1 new integration test |

## Test plan

- [x] 16 unit tests covering: standard front matter, no front matter, empty front matter, mid-document `---`, line-1 requirement, invalid YAML, scalar/array YAML, multi-line values, trailing whitespace on delimiters
- [x] 1 integration test: temp prompt file with front matter → route delivery → verify `launch_prompt` stripped, `launch_prompt_meta` populated
- [x] `pnpm build` — 18/18 packages
- [x] `pnpm test` — 1000 tests passing
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)