### PR TITLE
chore(deps-dev): bump biome 2.x, vitest 4.x, turbo, @types/node

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,6 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.0/schema.json",
-	"organizeImports": {
-		"enabled": true
-	},
+	"$schema": "https://biomejs.dev/schemas/2.4.0/schema.json",
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"formatter": {
 		"enabled": true,
 		"indentStyle": "tab",
@@ -17,7 +15,8 @@
 				"noForEach": "off"
 			},
 			"suspicious": {
-				"noThenProperty": "off"
+				"noThenProperty": "off",
+				"noTemplateCurlyInString": "off"
 			},
 			"style": {
 				"noNonNullAssertion": "error"
@@ -32,6 +31,6 @@
 		}
 	},
 	"files": {
-		"ignore": ["node_modules", "dist", "*.json", "docs-site/.astro"]
+		"includes": ["**", "!**/node_modules", "!**/dist", "!**/*.json", "!**/docs-site/.astro"]
 	}
 }

--- a/connectors/cron/src/__tests__/cron.test.ts
+++ b/connectors/cron/src/__tests__/cron.test.ts
@@ -314,7 +314,7 @@ describe('CronSource', () => {
 
 		// Monday 2026-02-09 at 8:00 AM checkpoint, poll at 9:05 AM
 		const before9am = new Date(2026, 1, 9, 8, 0, 0).toISOString();
-		const checkpoint = JSON.stringify({ standup: before9am });
+		const _checkpoint = JSON.stringify({ standup: before9am });
 
 		// Mock "now" by injecting a checkpoint that is 65 minutes old from 9:05
 		// The findLastMatch should find 9:00 between 8:00 and now

--- a/connectors/cron/src/source.ts
+++ b/connectors/cron/src/source.ts
@@ -8,8 +8,8 @@
  * any scheduled cron time has passed since the last checkpoint.
  */
 
-import { buildEvent, parseDuration } from '@orgloop/sdk';
 import type { OrgLoopEvent, PollResult, SourceConfig, SourceConnector } from '@orgloop/sdk';
+import { buildEvent, parseDuration } from '@orgloop/sdk';
 
 /** A single schedule definition from config */
 export interface CronSchedule {

--- a/connectors/gog/src/__tests__/source.test.ts
+++ b/connectors/gog/src/__tests__/source.test.ts
@@ -2,8 +2,8 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { GogSource } from '../source.js';
 import type { GogMessage } from '../source.js';
+import { GogSource } from '../source.js';
 
 // ─── Mock Helpers ──────────────────────────────────────────────────────────────
 
@@ -234,7 +234,7 @@ describe('GogSource', () => {
 			const source = await createSource();
 			const msg = makeMessage({ id: 'msg-dup' });
 
-			const pollCount = 0;
+			const _pollCount = 0;
 			mockExecGog(source, async (args) => {
 				if (args.includes('messages') && args.includes('search')) {
 					return [msg];
@@ -612,15 +612,8 @@ describe('GogSource', () => {
 		it('passes gog_client when configured', async () => {
 			const source = await createSource({ gog_client: 'my-client' });
 
-			// Verify by checking the real execGog builds the right args
-			// We need to mock at a lower level — mock child_process
-			const { execFile } = await import('node:child_process');
-			const { promisify } = await import('node:util');
-
-			// Instead, just verify via the mock
-			let capturedArgs: string[] = [];
-			mockExecGog(source, async (args) => {
-				capturedArgs = args;
+			// Verify via the mock
+			mockExecGog(source, async () => {
 				return [];
 			});
 

--- a/connectors/gog/src/source.ts
+++ b/connectors/gog/src/source.ts
@@ -395,25 +395,6 @@ export class GogSource implements SourceConnector {
 		return { records: [], historyId: undefined };
 	}
 
-	private extractHistoryId(result: unknown): string | undefined {
-		if (result && typeof result === 'object') {
-			const obj = result as { historyId?: string };
-			if (obj.historyId) return obj.historyId;
-
-			// If it's a history list, take the last record's ID
-			if (Array.isArray(result) && result.length > 0) {
-				const last = result[result.length - 1] as GogHistoryRecord;
-				return last.id;
-			}
-
-			const withHistory = result as { history?: GogHistoryRecord[] };
-			if (withHistory.history?.length) {
-				return withHistory.history[withHistory.history.length - 1].id;
-			}
-		}
-		return undefined;
-	}
-
 	// ─── Event Building ─────────────────────────────────────────────────────
 
 	private async messageToEvent(msg: GogMessage): Promise<OrgLoopEvent | null> {

--- a/connectors/linear/src/__tests__/source.test.ts
+++ b/connectors/linear/src/__tests__/source.test.ts
@@ -2,8 +2,8 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { LinearSource } from '../source.js';
 import type { CachedIssueState } from '../source.js';
+import { LinearSource } from '../source.js';
 
 // ─── Mock Helpers ──────────────────────────────────────────────────────────────
 
@@ -539,7 +539,7 @@ describe('LinearSource', () => {
 
 			// Track issue poll calls vs comment poll calls
 			let issueCallCount = 0;
-			const issuesFn = vi.fn().mockImplementation((opts: { after?: string }) => {
+			const issuesFn = vi.fn().mockImplementation((_opts: { after?: string }) => {
 				// pollComments also calls team.issues — return empty for that
 				issueCallCount++;
 				if (issueCallCount === 1) return page1;

--- a/connectors/openclaw/src/__tests__/target.test.ts
+++ b/connectors/openclaw/src/__tests__/target.test.ts
@@ -1,5 +1,5 @@
-import { createTestEvent } from '@orgloop/sdk';
 import type { RouteDeliveryConfig } from '@orgloop/sdk';
+import { createTestEvent } from '@orgloop/sdk';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { OpenClawTarget } from '../target.js';
 

--- a/loggers/file/src/__tests__/logger.test.ts
+++ b/loggers/file/src/__tests__/logger.test.ts
@@ -2,7 +2,7 @@
  * Tests for FileLogger — JSONL write, buffering, rotation, path expansion, error resilience.
  */
 
-import { mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { LogEntry } from '@orgloop/sdk';

--- a/loggers/file/src/file-logger.ts
+++ b/loggers/file/src/file-logger.ts
@@ -9,7 +9,7 @@ import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import type { LogEntry, Logger } from '@orgloop/sdk';
 import { parseDuration } from '@orgloop/sdk';
-import { type RotationConfig, needsRotation, parseSize, rotateFile } from './rotation.js';
+import { needsRotation, parseSize, type RotationConfig, rotateFile } from './rotation.js';
 
 interface FileLoggerConfig {
 	path?: string;

--- a/loggers/file/src/index.ts
+++ b/loggers/file/src/index.ts
@@ -55,4 +55,4 @@ export function register(): LoggerRegistration {
 }
 
 export { FileLogger } from './file-logger.js';
-export { parseSize, rotateFile, needsRotation } from './rotation.js';
+export { needsRotation, parseSize, rotateFile } from './rotation.js';

--- a/loggers/otel/src/__tests__/logger.test.ts
+++ b/loggers/otel/src/__tests__/logger.test.ts
@@ -19,7 +19,7 @@ interface EmittedRecord {
 }
 
 const emittedRecords: EmittedRecord[] = [];
-let mockExporterShutdownCalled = false;
+let _mockExporterShutdownCalled = false;
 let mockProviderForceFlushCalled = false;
 let mockProviderShutdownCalled = false;
 let mockExporterConfig: Record<string, unknown> = {};
@@ -31,7 +31,7 @@ let exporterShouldFail = false;
 
 function resetMocks() {
 	emittedRecords.length = 0;
-	mockExporterShutdownCalled = false;
+	_mockExporterShutdownCalled = false;
 	mockProviderForceFlushCalled = false;
 	mockProviderShutdownCalled = false;
 	mockExporterConfig = {};
@@ -67,7 +67,7 @@ vi.mock('@opentelemetry/exporter-logs-otlp-http', () => ({
 			}
 		}
 		shutdown() {
-			mockExporterShutdownCalled = true;
+			_mockExporterShutdownCalled = true;
 			return Promise.resolve();
 		}
 	},

--- a/loggers/otel/src/index.ts
+++ b/loggers/otel/src/index.ts
@@ -70,5 +70,4 @@ export function register(): LoggerRegistration {
 	};
 }
 
-export { OtelLogger } from './otel-logger.js';
-export { PHASE_SEVERITY } from './otel-logger.js';
+export { OtelLogger, PHASE_SEVERITY } from './otel-logger.js';

--- a/loggers/otel/src/otel-logger.ts
+++ b/loggers/otel/src/otel-logger.ts
@@ -6,7 +6,7 @@
  */
 
 import type { LoggerProvider } from '@opentelemetry/sdk-logs';
-import type { LogEntry, LogPhase, Logger } from '@orgloop/sdk';
+import type { LogEntry, Logger, LogPhase } from '@orgloop/sdk';
 
 /** Phase → OTel severity number mapping (follows OTel severity spec) */
 const PHASE_SEVERITY: Record<LogPhase, { text: string; number: number }> = {

--- a/loggers/syslog/src/__tests__/logger.test.ts
+++ b/loggers/syslog/src/__tests__/logger.test.ts
@@ -7,8 +7,8 @@
 
 import type { LogEntry, LogPhase } from '@orgloop/sdk';
 import { register } from '../index.js';
-import { SyslogLogger, formatRfc5424, getSeverity } from '../syslog-logger.js';
 import type { SyslogTransport } from '../syslog-logger.js';
+import { formatRfc5424, getSeverity, SyslogLogger } from '../syslog-logger.js';
 
 // ─── Test Helpers ────────────────────────────────────────────────────────────
 

--- a/loggers/syslog/src/index.ts
+++ b/loggers/syslog/src/index.ts
@@ -76,12 +76,12 @@ export function register(): LoggerRegistration {
 	};
 }
 
-export { SyslogLogger } from './syslog-logger.js';
+export type { SyslogLoggerConfig, SyslogTransport } from './syslog-logger.js';
 export {
 	formatRfc5424,
 	getSeverity,
-	UdpTransport,
+	SyslogLogger,
 	TcpTransport,
+	UdpTransport,
 	UnixTransport,
 } from './syslog-logger.js';
-export type { SyslogTransport, SyslogLoggerConfig } from './syslog-logger.js';

--- a/loggers/syslog/src/syslog-logger.ts
+++ b/loggers/syslog/src/syslog-logger.ts
@@ -5,10 +5,10 @@
  * and Unix socket transports. Zero external dependencies.
  */
 
-import { type Socket as UdpSocket, createSocket } from 'node:dgram';
-import { type Socket as TcpSocket, createConnection } from 'node:net';
+import { createSocket, type Socket as UdpSocket } from 'node:dgram';
+import { createConnection, type Socket as TcpSocket } from 'node:net';
 import { hostname } from 'node:os';
-import type { LogEntry, LogPhase, Logger } from '@orgloop/sdk';
+import type { LogEntry, Logger, LogPhase } from '@orgloop/sdk';
 
 // ─── RFC 5424 Facilities ─────────────────────────────────────────────────────
 

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "release:dry": "bash scripts/release.sh --dry-run"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.0",
-    "@types/node": "^25.2.2",
-    "turbo": "^2.3.0",
+    "@biomejs/biome": "^2.4.0",
+    "@types/node": "^25.2.3",
+    "turbo": "^2.8.9",
     "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/cli/src/__tests__/cli-dx.test.ts
+++ b/packages/cli/src/__tests__/cli-dx.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { scanEnvVars } from '../commands/env.js';
 import type { EnvWarning } from '../commands/validate.js';
 
@@ -43,9 +43,7 @@ connectors:
 		);
 
 		// Ensure vars are unset
-		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 		delete process.env.ORGLOOP_TEST_VALIDATE_TOKEN;
-		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 		delete process.env.ORGLOOP_TEST_VALIDATE_REPO;
 
 		const envVars = await scanEnvVars(join(tempDir, 'orgloop.yaml'));
@@ -97,7 +95,6 @@ connectors:
 
 			expect(envWarnings).toHaveLength(0);
 		} finally {
-			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 			delete process.env.ORGLOOP_TEST_VALIDATE_SET;
 		}
 	});
@@ -127,7 +124,6 @@ connectors:
 		);
 
 		process.env.ORGLOOP_TEST_MIX_PRESENT = 'yes';
-		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 		delete process.env.ORGLOOP_TEST_MIX_MISSING;
 
 		try {
@@ -142,7 +138,6 @@ connectors:
 			expect(envWarnings).toHaveLength(1);
 			expect(envWarnings[0].name).toBe('ORGLOOP_TEST_MIX_MISSING');
 		} finally {
-			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 			delete process.env.ORGLOOP_TEST_MIX_PRESENT;
 		}
 	});
@@ -187,11 +182,8 @@ connectors:
 		);
 
 		// Ensure all vars are unset
-		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 		delete process.env.ORGLOOP_TEST_A;
-		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 		delete process.env.ORGLOOP_TEST_B;
-		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 		delete process.env.ORGLOOP_TEST_C;
 
 		const envVars = await scanEnvVars(join(tempDir, 'orgloop.yaml'));
@@ -247,7 +239,6 @@ connectors:
 
 			expect(missing).toHaveLength(0);
 		} finally {
-			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 			delete process.env.ORGLOOP_TEST_PREFLIGHT_OK;
 		}
 	});

--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -1,15 +1,9 @@
-import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { CredentialValidator, ServiceDetector } from '@orgloop/sdk';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import {
-	type DoctorResult,
-	checkCredentials,
-	checkServices,
-	checkValidation,
-	runDoctor,
-} from '../commands/doctor.js';
+import { checkCredentials, checkServices, checkValidation, runDoctor } from '../commands/doctor.js';
 
 describe('doctor command', () => {
 	let tempDir: string;
@@ -204,19 +198,16 @@ connectors:
 				expect(okChecks.length).toBe(3);
 			} finally {
 				if (origRepo === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete
 					delete process.env.GITHUB_REPO;
 				} else {
 					process.env.GITHUB_REPO = origRepo;
 				}
 				if (origToken === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete
 					delete process.env.GITHUB_TOKEN;
 				} else {
 					process.env.GITHUB_TOKEN = origToken;
 				}
 				if (origAgent === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete
 					delete process.env.OPENCLAW_AGENT_ID;
 				} else {
 					process.env.OPENCLAW_AGENT_ID = origAgent;
@@ -231,11 +222,8 @@ connectors:
 			const origRepo = process.env.GITHUB_REPO;
 			const origToken = process.env.GITHUB_TOKEN;
 			const origAgent = process.env.OPENCLAW_AGENT_ID;
-			// biome-ignore lint/performance/noDelete: process.env requires delete
 			delete process.env.GITHUB_REPO;
-			// biome-ignore lint/performance/noDelete: process.env requires delete
 			delete process.env.GITHUB_TOKEN;
-			// biome-ignore lint/performance/noDelete: process.env requires delete
 			delete process.env.OPENCLAW_AGENT_ID;
 
 			try {
@@ -288,19 +276,16 @@ connectors:
 				expect(result.checks.every((c) => c.status === 'ok')).toBe(true);
 			} finally {
 				if (origRepo === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete
 					delete process.env.GITHUB_REPO;
 				} else {
 					process.env.GITHUB_REPO = origRepo;
 				}
 				if (origToken === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete
 					delete process.env.GITHUB_TOKEN;
 				} else {
 					process.env.GITHUB_TOKEN = origToken;
 				}
 				if (origAgent === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete
 					delete process.env.OPENCLAW_AGENT_ID;
 				} else {
 					process.env.OPENCLAW_AGENT_ID = origAgent;
@@ -315,11 +300,8 @@ connectors:
 			const origRepo = process.env.GITHUB_REPO;
 			const origToken = process.env.GITHUB_TOKEN;
 			const origAgent = process.env.OPENCLAW_AGENT_ID;
-			// biome-ignore lint/performance/noDelete: process.env requires delete
 			delete process.env.GITHUB_REPO;
-			// biome-ignore lint/performance/noDelete: process.env requires delete
 			delete process.env.GITHUB_TOKEN;
-			// biome-ignore lint/performance/noDelete: process.env requires delete
 			delete process.env.OPENCLAW_AGENT_ID;
 
 			try {
@@ -399,19 +381,16 @@ connectors:
 				expect(tokenCheck?.scopes).toEqual(['repo', 'read:org']);
 			} finally {
 				if (origToken === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete
 					delete process.env.GITHUB_TOKEN;
 				} else {
 					process.env.GITHUB_TOKEN = origToken;
 				}
 				if (origRepo === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete
 					delete process.env.GITHUB_REPO;
 				} else {
 					process.env.GITHUB_REPO = origRepo;
 				}
 				if (origAgent === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete
 					delete process.env.OPENCLAW_AGENT_ID;
 				} else {
 					process.env.OPENCLAW_AGENT_ID = origAgent;
@@ -447,19 +426,16 @@ connectors:
 				expect(tokenCheck?.detail).toContain('Invalid token');
 			} finally {
 				if (origToken === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete
 					delete process.env.GITHUB_TOKEN;
 				} else {
 					process.env.GITHUB_TOKEN = origToken;
 				}
 				if (origRepo === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete
 					delete process.env.GITHUB_REPO;
 				} else {
 					process.env.GITHUB_REPO = origRepo;
 				}
 				if (origAgent === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete
 					delete process.env.OPENCLAW_AGENT_ID;
 				} else {
 					process.env.OPENCLAW_AGENT_ID = origAgent;
@@ -491,19 +467,16 @@ connectors:
 				}
 			} finally {
 				if (origRepo === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete
 					delete process.env.GITHUB_REPO;
 				} else {
 					process.env.GITHUB_REPO = origRepo;
 				}
 				if (origToken === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete
 					delete process.env.GITHUB_TOKEN;
 				} else {
 					process.env.GITHUB_TOKEN = origToken;
 				}
 				if (origAgent === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete
 					delete process.env.OPENCLAW_AGENT_ID;
 				} else {
 					process.env.OPENCLAW_AGENT_ID = origAgent;
@@ -537,19 +510,16 @@ connectors:
 				expect(tokenCheck?.status).toBe('ok');
 			} finally {
 				if (origToken === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete
 					delete process.env.GITHUB_TOKEN;
 				} else {
 					process.env.GITHUB_TOKEN = origToken;
 				}
 				if (origRepo === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete
 					delete process.env.GITHUB_REPO;
 				} else {
 					process.env.GITHUB_REPO = origRepo;
 				}
 				if (origAgent === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete
 					delete process.env.OPENCLAW_AGENT_ID;
 				} else {
 					process.env.OPENCLAW_AGENT_ID = origAgent;

--- a/packages/cli/src/__tests__/dotenv.test.ts
+++ b/packages/cli/src/__tests__/dotenv.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -23,9 +23,7 @@ describe('loadDotEnv', () => {
 		await writeFile(join(tempDir, '.env'), 'DOTENV_TEST_A=hello\nDOTENV_TEST_B=world\n');
 
 		// Ensure vars are not set
-		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 		delete process.env.DOTENV_TEST_A;
-		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 		delete process.env.DOTENV_TEST_B;
 
 		try {
@@ -35,9 +33,7 @@ describe('loadDotEnv', () => {
 			expect(process.env.DOTENV_TEST_A).toBe('hello');
 			expect(process.env.DOTENV_TEST_B).toBe('world');
 		} finally {
-			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 			delete process.env.DOTENV_TEST_A;
-			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 			delete process.env.DOTENV_TEST_B;
 		}
 	});
@@ -52,7 +48,6 @@ describe('loadDotEnv', () => {
 			'# This is a comment\n\nDOTENV_TEST_COMMENT=yes\n  # indented comment\n',
 		);
 
-		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 		delete process.env.DOTENV_TEST_COMMENT;
 
 		try {
@@ -60,7 +55,6 @@ describe('loadDotEnv', () => {
 			expect(loaded).toEqual(['DOTENV_TEST_COMMENT']);
 			expect(process.env.DOTENV_TEST_COMMENT).toBe('yes');
 		} finally {
-			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 			delete process.env.DOTENV_TEST_COMMENT;
 		}
 	});
@@ -75,9 +69,7 @@ describe('loadDotEnv', () => {
 			'DOTENV_TEST_DQ="double quoted"\nDOTENV_TEST_SQ=\'single quoted\'\n',
 		);
 
-		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 		delete process.env.DOTENV_TEST_DQ;
-		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 		delete process.env.DOTENV_TEST_SQ;
 
 		try {
@@ -87,9 +79,7 @@ describe('loadDotEnv', () => {
 			expect(process.env.DOTENV_TEST_DQ).toBe('double quoted');
 			expect(process.env.DOTENV_TEST_SQ).toBe('single quoted');
 		} finally {
-			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 			delete process.env.DOTENV_TEST_DQ;
-			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 			delete process.env.DOTENV_TEST_SQ;
 		}
 	});
@@ -108,7 +98,6 @@ describe('loadDotEnv', () => {
 			expect(loaded).not.toContain('DOTENV_TEST_EXISTING');
 			expect(process.env.DOTENV_TEST_EXISTING).toBe('from-shell');
 		} finally {
-			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 			delete process.env.DOTENV_TEST_EXISTING;
 		}
 	});
@@ -133,7 +122,6 @@ describe('loadDotEnv', () => {
 			'DOTENV_TEST_NEW=new-value\nDOTENV_TEST_OLD=old-value\n',
 		);
 
-		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 		delete process.env.DOTENV_TEST_NEW;
 		process.env.DOTENV_TEST_OLD = 'already-set';
 
@@ -143,9 +131,7 @@ describe('loadDotEnv', () => {
 			expect(process.env.DOTENV_TEST_NEW).toBe('new-value');
 			expect(process.env.DOTENV_TEST_OLD).toBe('already-set');
 		} finally {
-			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 			delete process.env.DOTENV_TEST_NEW;
-			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 			delete process.env.DOTENV_TEST_OLD;
 		}
 	});

--- a/packages/cli/src/__tests__/env-command.test.ts
+++ b/packages/cli/src/__tests__/env-command.test.ts
@@ -238,7 +238,6 @@ loggers:
 
 			// Ensure another var is unset — delete is required for process.env
 			const origMissing = process.env.ORGLOOP_TEST_MISSING_VAR;
-			// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 			delete process.env.ORGLOOP_TEST_MISSING_VAR;
 
 			try {
@@ -246,7 +245,6 @@ loggers:
 				expect(process.env.ORGLOOP_TEST_MISSING_VAR).toBeUndefined();
 			} finally {
 				if (origVal === undefined) {
-					// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 					delete process.env.ORGLOOP_TEST_SET_VAR;
 				} else {
 					process.env.ORGLOOP_TEST_SET_VAR = origVal;

--- a/packages/cli/src/__tests__/hook.test.ts
+++ b/packages/cli/src/__tests__/hook.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
-import { type IncomingMessage, type Server, type ServerResponse, createServer } from 'node:http';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';

--- a/packages/cli/src/__tests__/module-e2e.test.ts
+++ b/packages/cli/src/__tests__/module-e2e.test.ts
@@ -5,7 +5,7 @@
  * composition (two modules sharing a source), namespacing (no collisions).
  */
 
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import yaml from 'js-yaml';
@@ -373,7 +373,7 @@ routes:
 describe('engineering module', () => {
 	it('loads the real engineering module manifest', async () => {
 		// Resolve the actual engineering module from the workspace
-		const engineeringPath = join(testDir, '../../..', 'modules', 'engineering');
+		const _engineeringPath = join(testDir, '../../..', 'modules', 'engineering');
 		// Use a direct path to the actual module in the repo
 		const repoRoot = join(__dirname, '..', '..', '..', '..');
 		const modulePath = join(repoRoot, 'modules', 'engineering');

--- a/packages/cli/src/__tests__/readme-e2e.test.ts
+++ b/packages/cli/src/__tests__/readme-e2e.test.ts
@@ -75,7 +75,7 @@ afterEach(async () => {
 describe('README onboarding flow', () => {
 	it('init → add module → doctor → plan completes successfully', async () => {
 		// ── Step 1: init ──────────────────────────────────────────────────
-		const initOutput = cli(
+		const _initOutput = cli(
 			'init --no-interactive --name test-org --connectors github,linear,openclaw,claude-code --dir .',
 			testDir,
 		);
@@ -239,7 +239,7 @@ routes:
 		const doctorResult = JSON.parse(doctorOutput);
 
 		// Should have route-graph warnings for the broken references
-		const routeGraphWarnings = doctorResult.checks.filter(
+		const _routeGraphWarnings = doctorResult.checks.filter(
 			(c: { category: string }) => c.category === 'route-graph',
 		);
 

--- a/packages/cli/src/__tests__/resolve-connectors.test.ts
+++ b/packages/cli/src/__tests__/resolve-connectors.test.ts
@@ -1,5 +1,5 @@
-import { MockActor, MockSource } from '@orgloop/sdk';
 import type { ConnectorRegistration, OrgLoopConfig } from '@orgloop/sdk';
+import { MockActor, MockSource } from '@orgloop/sdk';
 import { describe, expect, it } from 'vitest';
 import { resolveConnectors } from '../resolve-connectors.js';
 

--- a/packages/cli/src/__tests__/routes.test.ts
+++ b/packages/cli/src/__tests__/routes.test.ts
@@ -5,9 +5,8 @@ import type {
 	SourceInstanceConfig,
 	TransformDefinition,
 } from '@orgloop/sdk';
-import chalk from 'chalk';
 import { describe, expect, it } from 'vitest';
-import { type RouteGraph, buildRouteGraph, renderRouteGraph } from '../commands/routes.js';
+import { buildRouteGraph, type RouteGraph, renderRouteGraph } from '../commands/routes.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/packages/cli/src/__tests__/start-doctor-gate.test.ts
+++ b/packages/cli/src/__tests__/start-doctor-gate.test.ts
@@ -69,7 +69,6 @@ connectors:
 		);
 
 		// Ensure the var is not set
-		// biome-ignore lint/performance/noDelete: process.env requires delete to truly unset
 		delete process.env.APPLY_DOCTOR_GATE_MISSING_VAR;
 
 		const result = await runDoctor(join(tempDir, 'orgloop.yaml'));

--- a/packages/cli/src/__tests__/validate-graph.test.ts
+++ b/packages/cli/src/__tests__/validate-graph.test.ts
@@ -5,7 +5,7 @@ import type {
 	TransformDefinition,
 } from '@orgloop/sdk';
 import { describe, expect, it } from 'vitest';
-import { type GraphWarning, validateRouteGraph } from '../commands/validate.js';
+import { validateRouteGraph } from '../commands/validate.js';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -5,7 +5,7 @@
  * which variables are set and which are missing.
  */
 
-import { access, readFile, readdir } from 'node:fs/promises';
+import { access, readdir, readFile } from 'node:fs/promises';
 import { dirname, isAbsolute, resolve } from 'node:path';
 import chalk from 'chalk';
 import type { Command } from 'commander';

--- a/packages/cli/src/commands/hook.ts
+++ b/packages/cli/src/commands/hook.ts
@@ -6,7 +6,7 @@
  * the OrgLoopEvent from the raw payload.
  */
 
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { Command } from 'commander';

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -25,7 +25,7 @@ const AVAILABLE_CONNECTORS = [
 	'pagerduty',
 ];
 
-function connectorYaml(name: string, role: 'source' | 'actor'): string {
+function connectorYaml(name: string, _role: 'source' | 'actor'): string {
 	const configs: Record<string, string> = {
 		github: `apiVersion: orgloop/v1alpha1
 kind: ConnectorGroup

--- a/packages/cli/src/commands/install-service.ts
+++ b/packages/cli/src/commands/install-service.ts
@@ -65,7 +65,7 @@ StandardError=append:${join(homedir(), '.orgloop', 'logs', 'daemon.stderr.log')}
 WantedBy=default.target`;
 }
 
-function generateDockerfile(configPath: string): string {
+function generateDockerfile(_configPath: string): string {
 	return `FROM node:22-slim
 
 WORKDIR /app

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -175,7 +175,7 @@ export function registerLogsCommand(program: Command): void {
 		.option('--since <duration>', 'Time range filter (e.g., 2h, 30m)')
 		.option('--format <format>', 'Output format: human (default) or json', 'human')
 		.option('--no-follow', 'Do not tail, just show existing entries')
-		.action(async (opts, cmd) => {
+		.action(async (opts, _cmd) => {
 			try {
 				const logFile = DEFAULT_LOG_FILE;
 

--- a/packages/cli/src/commands/plan.ts
+++ b/packages/cli/src/commands/plan.ts
@@ -10,7 +10,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { OrgLoopConfig } from '@orgloop/sdk';
 import type { Command } from 'commander';
-import { loadCliConfig, resolveConfigPath } from '../config.js';
+import { loadCliConfig } from '../config.js';
 import * as output from '../output.js';
 
 // ─── Running state ───────────────────────────────────────────────────────────

--- a/packages/cli/src/commands/routes.ts
+++ b/packages/cli/src/commands/routes.ts
@@ -8,13 +8,7 @@
  * Supports --json for machine-readable graph output.
  */
 
-import type {
-	ActorInstanceConfig,
-	OrgLoopConfig,
-	RouteDefinition,
-	SourceInstanceConfig,
-	TransformDefinition,
-} from '@orgloop/sdk';
+import type { OrgLoopConfig } from '@orgloop/sdk';
 import chalk from 'chalk';
 import type { Command } from 'commander';
 import { loadCliConfig, resolveConfigPath } from '../config.js';

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -321,7 +321,7 @@ async function runForeground(configPath?: string, force?: boolean): Promise<void
 		}
 
 		// Periodically write health state to state file
-		const healthInterval = setInterval(async () => {
+		const _healthInterval = setInterval(async () => {
 			try {
 				const status = runtime.status();
 				const state = JSON.parse(await readFile(STATE_FILE, 'utf-8').catch(() => '{}'));

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -6,7 +6,7 @@
  */
 
 import { constants } from 'node:fs';
-import { access, readFile, stat } from 'node:fs/promises';
+import { access, readFile } from 'node:fs/promises';
 import { dirname, isAbsolute, resolve } from 'node:path';
 import type {
 	ActorInstanceConfig,
@@ -97,9 +97,9 @@ function validateProjectSchema(data: unknown, filePath: string): ValidationResul
 }
 
 async function validateReferences(
-	basePath: string,
+	_basePath: string,
 	routesDir: string,
-	project: ProjectConfig,
+	_project: ProjectConfig,
 	sources: Map<string, SourceInstanceConfig>,
 	actors: Map<string, ActorInstanceConfig>,
 	transforms: Map<string, TransformDefinition>,
@@ -492,7 +492,7 @@ export async function runValidation(configPath: string): Promise<{
 		}
 
 		try {
-			const data = (await loadYaml(filePath)) as LoggerYaml;
+			const _data = (await loadYaml(filePath)) as LoggerYaml;
 			results.push({ file: file, valid: true, description: 'valid logger group', errors: [] });
 		} catch (err) {
 			results.push({
@@ -605,7 +605,7 @@ export function registerValidateCommand(program: Command): void {
 	program
 		.command('validate')
 		.description('Validate configuration files')
-		.action(async (opts, cmd) => {
+		.action(async (_opts, cmd) => {
 			try {
 				const globalOpts = cmd.parent?.opts() ?? {};
 				const configPath = resolveConfigPath(globalOpts.config);

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -5,7 +5,7 @@
  * resolves environment variables, merges with user defaults.
  */
 
-import { access, readFile, readdir } from 'node:fs/promises';
+import { access, readdir, readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { isAbsolute, join, resolve } from 'node:path';
 import type { OrgLoopConfig, ProjectConfig } from '@orgloop/sdk';

--- a/packages/cli/src/module-resolver.ts
+++ b/packages/cli/src/module-resolver.ts
@@ -8,9 +8,9 @@
 import { readFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import type { ModuleExpansionContext, ModuleManifest, RouteDefinition } from '@orgloop/sdk';
-import { expandTemplateDeep, moduleManifestSchema } from '@orgloop/sdk';
-import AjvModule from 'ajv';
+import { moduleManifestSchema } from '@orgloop/sdk';
 import type { ErrorObject } from 'ajv';
+import AjvModule from 'ajv';
 import yaml from 'js-yaml';
 
 const Ajv = AjvModule.default ?? AjvModule;

--- a/packages/core/src/__tests__/bus.test.ts
+++ b/packages/core/src/__tests__/bus.test.ts
@@ -1,5 +1,5 @@
-import { createTestEvent } from '@orgloop/sdk';
 import type { OrgLoopEvent } from '@orgloop/sdk';
+import { createTestEvent } from '@orgloop/sdk';
 import { describe, expect, it } from 'vitest';
 import { InMemoryBus } from '../bus.js';
 

--- a/packages/core/src/__tests__/engine-integration.test.ts
+++ b/packages/core/src/__tests__/engine-integration.test.ts
@@ -1,5 +1,5 @@
-import { MockActor, MockLogger, MockSource, MockTransform, createTestEvent } from '@orgloop/sdk';
 import type { OrgLoopConfig, OrgLoopEvent, Transform, TransformContext } from '@orgloop/sdk';
+import { createTestEvent, MockActor, MockLogger, MockSource, MockTransform } from '@orgloop/sdk';
 import { describe, expect, it } from 'vitest';
 import { OrgLoop } from '../engine.js';
 

--- a/packages/core/src/__tests__/health-tracking.test.ts
+++ b/packages/core/src/__tests__/health-tracking.test.ts
@@ -1,5 +1,5 @@
-import { MockActor, MockSource, createTestEvent } from '@orgloop/sdk';
 import type { OrgLoopConfig, SourceHealthState } from '@orgloop/sdk';
+import { createTestEvent, MockActor, MockSource } from '@orgloop/sdk';
 import { describe, expect, it, vi } from 'vitest';
 import { OrgLoop } from '../engine.js';
 

--- a/packages/core/src/__tests__/http.test.ts
+++ b/packages/core/src/__tests__/http.test.ts
@@ -1,6 +1,6 @@
 import http from 'node:http';
-import { MockActor, MockSource, createTestEvent } from '@orgloop/sdk';
 import type { OrgLoopConfig, OrgLoopEvent, WebhookHandler } from '@orgloop/sdk';
+import { createTestEvent, MockActor, MockSource } from '@orgloop/sdk';
 import { describe, expect, it } from 'vitest';
 import { OrgLoop } from '../engine.js';
 import { WebhookServer } from '../http.js';

--- a/packages/core/src/__tests__/module-instance.test.ts
+++ b/packages/core/src/__tests__/module-instance.test.ts
@@ -1,7 +1,7 @@
 import { MockActor, MockLogger, MockSource, MockTransform } from '@orgloop/sdk';
 import { describe, expect, it } from 'vitest';
-import { ModuleInstance } from '../module-instance.js';
 import type { ModuleConfig } from '../module-instance.js';
+import { ModuleInstance } from '../module-instance.js';
 import { InMemoryCheckpointStore } from '../store.js';
 
 function makeConfig(overrides?: Partial<ModuleConfig>): ModuleConfig {

--- a/packages/core/src/__tests__/pipeline-e2e.test.ts
+++ b/packages/core/src/__tests__/pipeline-e2e.test.ts
@@ -1,5 +1,4 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import { MockActor, MockLogger, MockSource, MockTransform, createTestEvent } from '@orgloop/sdk';
 import type {
 	OrgLoopConfig,
 	OrgLoopEvent,
@@ -7,7 +6,14 @@ import type {
 	SourceConfig,
 	WebhookHandler,
 } from '@orgloop/sdk';
-import { buildEvent } from '@orgloop/sdk';
+import {
+	buildEvent,
+	createTestEvent,
+	MockActor,
+	MockLogger,
+	MockSource,
+	MockTransform,
+} from '@orgloop/sdk';
 import { describe, expect, it } from 'vitest';
 import { OrgLoop } from '../engine.js';
 

--- a/packages/core/src/__tests__/registry.test.ts
+++ b/packages/core/src/__tests__/registry.test.ts
@@ -1,7 +1,6 @@
-import { MockActor, MockLogger, MockSource, MockTransform } from '@orgloop/sdk';
 import { describe, expect, it } from 'vitest';
-import { ModuleInstance } from '../module-instance.js';
 import type { ModuleConfig } from '../module-instance.js';
+import { ModuleInstance } from '../module-instance.js';
 import { ModuleRegistry } from '../registry.js';
 import { InMemoryCheckpointStore } from '../store.js';
 

--- a/packages/core/src/__tests__/router.test.ts
+++ b/packages/core/src/__tests__/router.test.ts
@@ -1,5 +1,5 @@
-import { createTestEvent } from '@orgloop/sdk';
 import type { RouteDefinition } from '@orgloop/sdk';
+import { createTestEvent } from '@orgloop/sdk';
 import { describe, expect, it } from 'vitest';
 import { matchRoutes } from '../router.js';
 

--- a/packages/core/src/__tests__/runtime.test.ts
+++ b/packages/core/src/__tests__/runtime.test.ts
@@ -2,13 +2,12 @@
  * Tests for the Runtime class — multi-module lifecycle management.
  */
 
-import { MockActor, MockLogger, MockSource, MockTransform, createTestEvent } from '@orgloop/sdk';
-import type { ModuleStatus, OrgLoopEvent } from '@orgloop/sdk';
+import type { OrgLoopEvent } from '@orgloop/sdk';
+import { createTestEvent, MockActor, MockSource, MockTransform } from '@orgloop/sdk';
 import { afterEach, describe, expect, it } from 'vitest';
 import { InMemoryBus } from '../bus.js';
 import type { ModuleConfig } from '../module-instance.js';
 import { Runtime } from '../runtime.js';
-import { InMemoryCheckpointStore } from '../store.js';
 
 function makeModuleConfig(name: string, overrides?: Partial<ModuleConfig>): ModuleConfig {
 	return {

--- a/packages/core/src/__tests__/transform-error-policy.test.ts
+++ b/packages/core/src/__tests__/transform-error-policy.test.ts
@@ -2,7 +2,6 @@
  * Transform error policy tests — verifies on_error: pass | drop | halt behavior.
  */
 
-import { MockActor, MockSource, createTestContext, createTestEvent } from '@orgloop/sdk';
 import type {
 	OrgLoopConfig,
 	OrgLoopEvent,
@@ -10,6 +9,7 @@ import type {
 	TransformContext,
 	TransformDefinition,
 } from '@orgloop/sdk';
+import { createTestContext, createTestEvent, MockActor, MockSource } from '@orgloop/sdk';
 import { describe, expect, it, vi } from 'vitest';
 import { OrgLoop } from '../engine.js';
 import { TransformError } from '../errors.js';

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -24,8 +24,8 @@ import type {
 import type { EventBus } from './bus.js';
 import { LoggerManager } from './logger.js';
 import type { ModuleConfig } from './module-instance.js';
-import { Runtime } from './runtime.js';
 import type { SourceCircuitBreakerOptions as RuntimeCircuitBreakerOptions } from './runtime.js';
+import { Runtime } from './runtime.js';
 import type { CheckpointStore } from './store.js';
 
 // ─── Engine Options ───────────────────────────────────────────────────────────

--- a/packages/core/src/http.ts
+++ b/packages/core/src/http.ts
@@ -6,7 +6,7 @@
  * No auth, no CORS — just local event ingestion.
  */
 
-import { type IncomingMessage, type ServerResponse, createServer } from 'node:http';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import type { OrgLoopEvent, WebhookHandler } from '@orgloop/sdk';
 
 export const DEFAULT_HTTP_PORT = 4800;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,31 +4,46 @@
  * Public API exports for library mode.
  */
 
+export type { BusHandler, EventBus } from './bus.js';
+// Event bus
+export { FileWalBus, InMemoryBus } from './bus.js';
+export type { EngineStatus, OrgLoopOptions, SourceCircuitBreakerOptions } from './engine.js';
 // Main engine
 export { OrgLoop } from './engine.js';
-export type { OrgLoopOptions, EngineStatus, SourceCircuitBreakerOptions } from './engine.js';
-
-// Config loading
-export { loadConfig, buildConfig } from './schema.js';
-export type { LoadConfigOptions } from './schema.js';
 
 // Errors
 export {
-	OrgLoopError,
 	ConfigError,
 	ConnectorError,
-	TransformError,
 	DeliveryError,
-	SchemaError,
 	ModuleConflictError,
 	ModuleNotFoundError,
+	OrgLoopError,
 	RuntimeError,
+	SchemaError,
+	TransformError,
 } from './errors.js';
-
-// Event bus
-export { InMemoryBus, FileWalBus } from './bus.js';
-export type { EventBus, BusHandler } from './bus.js';
-
+export type { RuntimeControl } from './http.js';
+// HTTP webhook server
+export { DEFAULT_HTTP_PORT, WebhookServer } from './http.js';
+// Logger manager
+export { LoggerManager } from './logger.js';
+export type { ModuleConfig, ModuleContext } from './module-instance.js';
+// Module system
+export { ModuleInstance } from './module-instance.js';
+export { ModuleRegistry } from './registry.js';
+export type { MatchedRoute } from './router.js';
+// Router
+export { matchRoutes } from './router.js';
+export type { LoadModuleOptions, RuntimeOptions } from './runtime.js';
+// Runtime (new architecture)
+export { Runtime } from './runtime.js';
+// Scheduler
+export { Scheduler } from './scheduler.js';
+export type { LoadConfigOptions } from './schema.js';
+// Config loading
+export { buildConfig, loadConfig } from './schema.js';
+export type { CheckpointStore, EventStore, WalEntry } from './store.js';
 // Stores
 export {
 	FileCheckpointStore,
@@ -36,31 +51,6 @@ export {
 	InMemoryCheckpointStore,
 	InMemoryEventStore,
 } from './store.js';
-export type { CheckpointStore, EventStore, WalEntry } from './store.js';
-
-// Router
-export { matchRoutes } from './router.js';
-export type { MatchedRoute } from './router.js';
-
+export type { TransformPipelineOptions, TransformPipelineResult } from './transform.js';
 // Transform pipeline
 export { executeTransformPipeline } from './transform.js';
-export type { TransformPipelineOptions, TransformPipelineResult } from './transform.js';
-
-// Logger manager
-export { LoggerManager } from './logger.js';
-
-// Scheduler
-export { Scheduler } from './scheduler.js';
-
-// HTTP webhook server
-export { WebhookServer, DEFAULT_HTTP_PORT } from './http.js';
-export type { RuntimeControl } from './http.js';
-
-// Runtime (new architecture)
-export { Runtime } from './runtime.js';
-export type { RuntimeOptions, LoadModuleOptions } from './runtime.js';
-
-// Module system
-export { ModuleInstance } from './module-instance.js';
-export type { ModuleConfig, ModuleContext } from './module-instance.js';
-export { ModuleRegistry } from './registry.js';

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -5,8 +5,7 @@
  * Non-blocking: errors in one logger don't affect others.
  */
 
-import type { LogEntry } from '@orgloop/sdk';
-import type { Logger } from '@orgloop/sdk';
+import type { LogEntry, Logger } from '@orgloop/sdk';
 
 interface TaggedLogger {
 	logger: Logger;

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -15,24 +15,23 @@ import type {
 	OrgLoopEvent,
 	RouteDeliveryConfig,
 	RuntimeStatus,
-	SourceHealthState,
 } from '@orgloop/sdk';
 import { generateTraceId } from '@orgloop/sdk';
 import type { EventBus } from './bus.js';
 import { InMemoryBus } from './bus.js';
-import { ConnectorError, DeliveryError, ModuleNotFoundError, RuntimeError } from './errors.js';
-import { DEFAULT_HTTP_PORT, WebhookServer } from './http.js';
+import { ConnectorError, DeliveryError, ModuleNotFoundError } from './errors.js';
 import type { RuntimeControl } from './http.js';
+import { DEFAULT_HTTP_PORT, WebhookServer } from './http.js';
 import { LoggerManager } from './logger.js';
-import type { ModuleConfig, ModuleContext } from './module-instance.js';
+import type { ModuleConfig } from './module-instance.js';
 import { ModuleInstance } from './module-instance.js';
 import { ModuleRegistry } from './registry.js';
 import { matchRoutes } from './router.js';
 import { Scheduler } from './scheduler.js';
 import type { CheckpointStore } from './store.js';
 import { InMemoryCheckpointStore } from './store.js';
-import { executeTransformPipeline } from './transform.js';
 import type { TransformPipelineOptions } from './transform.js';
+import { executeTransformPipeline } from './transform.js';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -7,10 +7,12 @@
 
 import { readFile } from 'node:fs/promises';
 import { dirname, isAbsolute, resolve } from 'node:path';
-import AjvModule from 'ajv';
 import type { ErrorObject } from 'ajv';
+import AjvModule from 'ajv';
 import yaml from 'js-yaml';
+
 const Ajv = AjvModule.default ?? AjvModule;
+
 import type {
 	ActorInstanceConfig,
 	LoggerDefinition,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -7,7 +7,7 @@
 
 import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import type { OrgLoopEvent } from '@orgloop/sdk';
 
 // ─── Checkpoint Store ─────────────────────────────────────────────────────────

--- a/packages/core/src/transform.ts
+++ b/packages/core/src/transform.ts
@@ -15,10 +15,11 @@ import type {
 	LogEntry,
 	OrgLoopEvent,
 	RouteTransformRef,
+	Transform,
+	TransformContext,
 	TransformDefinition,
 	TransformErrorPolicy,
 } from '@orgloop/sdk';
-import type { Transform, TransformContext } from '@orgloop/sdk';
 import { TransformError } from './errors.js';
 
 // ─── Script Transform Execution ──────────────────────────────────────────────

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -25,6 +25,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^25.2.2"
+    "@types/node": "^25.2.3"
   }
 }

--- a/packages/sdk/src/__tests__/module.test.ts
+++ b/packages/sdk/src/__tests__/module.test.ts
@@ -2,8 +2,8 @@
  * Tests for module manifest types and parameter expansion engine.
  */
 
-import { expandTemplate, expandTemplateDeep, moduleManifestSchema } from '../module.js';
 import type { ModuleExpansionContext, ModuleManifest } from '../module.js';
+import { expandTemplate, expandTemplateDeep, moduleManifestSchema } from '../module.js';
 
 // ─── expandTemplate ──────────────────────────────────────────────────────────
 

--- a/packages/sdk/src/__tests__/testing.test.ts
+++ b/packages/sdk/src/__tests__/testing.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
+	createTestContext,
+	createTestEvent,
 	MockActor,
 	MockLogger,
 	MockSource,
 	MockTransform,
-	createTestContext,
-	createTestEvent,
 } from '../testing.js';
 
 describe('MockSource', () => {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -5,112 +5,104 @@
  * for building OrgLoop plugins (connectors, transforms, loggers).
  */
 
-// Core types
-export type {
-	OrgLoopEvent,
-	OrgLoopEventType,
-	AuthorType,
-	EventProvenance,
-	SourceConfig,
-	ActorConfig,
-	PollConfig,
-	RouteDefinition,
-	RouteWhen,
-	RouteTransformRef,
-	RouteThen,
-	RouteWith,
-	RouteDeliveryConfig,
-	TransformDefinition,
-	TransformErrorPolicy,
-	LoggerDefinition,
-	DeliveryConfig,
-	RetryConfig,
-	CircuitBreakerConfig,
-	LogPhase,
-	LogEntry,
-	ProjectConfig,
-	OrgLoopConfig,
-	SourceInstanceConfig,
-	ActorInstanceConfig,
-	EventFilter,
-	EventHandler,
-	Subscription,
-	DurationString,
-	SourceHealthStatus,
-	SourceHealthState,
-	ModuleState,
-	ModuleStatus,
-	RuntimeStatus,
-	BootModuleEntry,
-	RuntimeConfig,
-} from './types.js';
-
-export { parseDuration } from './types.js';
-
 // Connector interfaces
 export type {
-	SourceConnector,
 	ActorConnector,
-	PollResult,
-	DeliveryResult,
-	WebhookHandler,
+	ConnectorIntegration,
 	ConnectorRegistration,
 	ConnectorSetup,
-	ConnectorIntegration,
-	EnvVarDefinition,
 	CredentialValidator,
+	DeliveryResult,
+	EnvVarDefinition,
+	PollResult,
 	ServiceDetector,
+	SourceConnector,
+	WebhookHandler,
 } from './connector.js';
-
+export type { BuildEventOptions, ValidationError } from './event.js';
+// Event helpers
+export {
+	buildEvent,
+	generateEventId,
+	generateTraceId,
+	isOrgLoopEvent,
+	validateEvent,
+} from './event.js';
+// Logger interface
+export type {
+	Logger,
+	LoggerRegistration,
+} from './logger.js';
+// Module types
+export type {
+	InstalledModule,
+	ModuleActorDefinition,
+	ModuleConnectorRequirement,
+	ModuleConnectors,
+	ModuleCredentialRequirement,
+	ModuleExpansionContext,
+	ModuleHookRequirement,
+	ModuleManifest,
+	ModuleMetadata,
+	ModuleParameter,
+	ModuleProvides,
+	ModuleRequirements,
+	ModuleServiceRequirement,
+	ModuleSourceDefinition,
+} from './module.js';
+export { expandTemplate, expandTemplateDeep, moduleManifestSchema } from './module.js';
+// Test harness
+export {
+	createTestContext,
+	createTestEvent,
+	MockActor,
+	MockLogger,
+	MockSource,
+	MockTransform,
+} from './testing.js';
 // Transform interface
 export type {
 	Transform,
 	TransformContext,
 	TransformRegistration,
 } from './transform.js';
-
-// Logger interface
+// Core types
 export type {
-	Logger,
-	LoggerRegistration,
-} from './logger.js';
-
-// Event helpers
-export {
-	generateEventId,
-	generateTraceId,
-	buildEvent,
-	validateEvent,
-	isOrgLoopEvent,
-} from './event.js';
-export type { BuildEventOptions, ValidationError } from './event.js';
-
-// Module types
-export type {
-	ModuleManifest,
-	ModuleMetadata,
-	ModuleRequirements,
-	ModuleConnectorRequirement,
-	ModuleServiceRequirement,
-	ModuleCredentialRequirement,
-	ModuleHookRequirement,
-	ModuleParameter,
-	ModuleProvides,
-	InstalledModule,
-	ModuleExpansionContext,
-	ModuleConnectors,
-	ModuleSourceDefinition,
-	ModuleActorDefinition,
-} from './module.js';
-
-export { expandTemplate, expandTemplateDeep, moduleManifestSchema } from './module.js';
-
-// Test harness
-export {
-	MockSource,
-	MockActor,
-	MockTransform,
-	MockLogger,
-	createTestEvent,
-	createTestContext,
-} from './testing.js';
+	ActorConfig,
+	ActorInstanceConfig,
+	AuthorType,
+	BootModuleEntry,
+	CircuitBreakerConfig,
+	DeliveryConfig,
+	DurationString,
+	EventFilter,
+	EventHandler,
+	EventProvenance,
+	LogEntry,
+	LoggerDefinition,
+	LogPhase,
+	ModuleState,
+	ModuleStatus,
+	OrgLoopConfig,
+	OrgLoopEvent,
+	OrgLoopEventType,
+	PollConfig,
+	ProjectConfig,
+	RetryConfig,
+	RouteDefinition,
+	RouteDeliveryConfig,
+	RouteThen,
+	RouteTransformRef,
+	RouteWhen,
+	RouteWith,
+	RuntimeConfig,
+	RuntimeStatus,
+	SourceConfig,
+	SourceHealthState,
+	SourceHealthStatus,
+	SourceInstanceConfig,
+	Subscription,
+	TransformDefinition,
+	TransformErrorPolicy,
+} from './types.js';
+export { parseDuration } from './types.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,20 +9,20 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: ^1.9.0
-        version: 1.9.4
+        specifier: ^2.4.0
+        version: 2.4.0
       '@types/node':
-        specifier: ^25.2.2
-        version: 25.2.2
+        specifier: ^25.2.3
+        version: 25.2.3
       turbo:
-        specifier: ^2.3.0
-        version: 2.8.3
+        specifier: ^2.8.9
+        version: 2.8.9
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.2.2)
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)
 
   connectors/claude-code:
     dependencies:
@@ -182,7 +182,7 @@ importers:
         version: 13.1.0
       inquirer:
         specifier: ^12.0.0
-        version: 12.11.1(@types/node@25.2.2)
+        version: 12.11.1(@types/node@25.2.3)
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.1
@@ -222,8 +222,8 @@ importers:
   packages/sdk:
     devDependencies:
       '@types/node':
-        specifier: ^25.2.2
-        version: 25.2.2
+        specifier: ^25.2.3
+        version: 25.2.3
 
   packages/server:
     dependencies:
@@ -254,55 +254,55 @@ importers:
 
 packages:
 
-  '@biomejs/biome@1.9.4':
-    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+  '@biomejs/biome@2.4.0':
+    resolution: {integrity: sha512-iluT61cORUDIC5i/y42ljyQraCemmmcgbMLLCnYO+yh+2hjTmcMFcwY8G0zTzWCsPb3t3AyKc+0t/VuhPZULUg==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
-    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+  '@biomejs/cli-darwin-arm64@2.4.0':
+    resolution: {integrity: sha512-L+YpOtPSuU0etomfvFTPWRsa7+8ejaJL3yaROEoT/96HDJbR6OsvZQk0C8JUYou+XFdP+JcGxqZknkp4n934RA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@1.9.4':
-    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+  '@biomejs/cli-darwin-x64@2.4.0':
+    resolution: {integrity: sha512-Aq+S7ffpb5ynTyLgtnEjG+W6xuTd2F7FdC7J6ShpvRhZwJhjzwITGF9vrqoOnw0sv1XWkt2Q1Rpg+hleg/Xg7Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
-    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+  '@biomejs/cli-linux-arm64-musl@2.4.0':
+    resolution: {integrity: sha512-1rhDUq8sf7xX3tg7vbnU3WVfanKCKi40OXc4VleBMzRStmQHdeBY46aFP6VdwEomcVjyNiu+Zcr3LZtAdrZrjQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@1.9.4':
-    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+  '@biomejs/cli-linux-arm64@2.4.0':
+    resolution: {integrity: sha512-u2p54IhvNAWB+h7+rxCZe3reNfQYFK+ppDw+q0yegrGclFYnDPZAntv/PqgUacpC3uxTeuWFgWW7RFe3lHuxOA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
-    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+  '@biomejs/cli-linux-x64-musl@2.4.0':
+    resolution: {integrity: sha512-Omo0xhl63z47X+CrE5viEWKJhejJyndl577VoXg763U/aoATrK3r5+8DPh02GokWPeODX1Hek00OtjjooGan9w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@1.9.4':
-    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+  '@biomejs/cli-linux-x64@2.4.0':
+    resolution: {integrity: sha512-WVFOhsnzhrbMGOSIcB9yFdRV2oG2KkRRhIZiunI9gJqSU3ax9ErdnTxRfJUxZUI9NbzVxC60OCXNcu+mXfF/Tw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@1.9.4':
-    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+  '@biomejs/cli-win32-arm64@2.4.0':
+    resolution: {integrity: sha512-aqRwW0LJLV1v1NzyLvLWQhdLmDSAV1vUh+OBdYJaa8f28XBn5BZavo+WTfqgEzALZxlNfBmu6NGO6Al3MbCULw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@1.9.4':
-    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+  '@biomejs/cli-win32-x64@2.4.0':
+    resolution: {integrity: sha512-g47s+V+OqsGxbSZN3lpav6WYOk0PIc3aCBAq+p6dwSynL3K5MA6Cg6nkzDOlu28GEHwbakW+BllzHCJCxnfK5Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -886,6 +886,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -901,8 +904,8 @@ packages:
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
-  '@types/node@25.2.2':
-    resolution: {integrity: sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==}
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
 
   '@types/through@0.0.33':
     resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
@@ -910,34 +913,34 @@ packages:
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
-  '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0-0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
 
-  '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
 
-  '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
@@ -964,12 +967,8 @@ packages:
   before-after-hook@3.0.2:
     resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
 
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
-  chai@5.3.3:
-    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   chalk@5.6.2:
@@ -978,10 +977,6 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
-
-  check-error@2.1.3:
-    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
-    engines: {node: '>= 16'}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -1005,19 +1000,6 @@ packages:
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
-
-  debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -1107,9 +1089,6 @@ packages:
   isomorphic-unfetch@3.1.0:
     resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
 
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
-
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -1124,18 +1103,12 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
-  loupe@3.2.1:
-    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
-
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
-
-  ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
@@ -1155,6 +1128,9 @@ packages:
       encoding:
         optional: true
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
@@ -1165,10 +1141,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pathval@2.0.1:
-    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
-    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1248,29 +1220,19 @@ packages:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
 
-  strip-literal@3.1.0:
-    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
-
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
-  tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@4.0.4:
-    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
   tr46@0.0.3:
@@ -1279,38 +1241,38 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  turbo-darwin-64@2.8.3:
-    resolution: {integrity: sha512-4kXRLfcygLOeNcP6JquqRLmGB/ATjjfehiojL2dJkL7GFm3SPSXbq7oNj8UbD8XriYQ5hPaSuz59iF1ijPHkTw==}
+  turbo-darwin-64@2.8.9:
+    resolution: {integrity: sha512-KnCw1ZI9KTnEAhdI9avZrnZ/z4wsM++flMA1w8s8PKOqi5daGpFV36qoPafg4S8TmYMe52JPWEoFr0L+lQ5JIw==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.8.3:
-    resolution: {integrity: sha512-xF7uCeC0UY0Hrv/tqax0BMbFlVP1J/aRyeGQPZT4NjvIPj8gSPDgFhfkfz06DhUwDg5NgMo04uiSkAWE8WB/QQ==}
+  turbo-darwin-arm64@2.8.9:
+    resolution: {integrity: sha512-CbD5Y2NKJKBXTOZ7z7Cc7vGlFPZkYjApA7ri9lH4iFwKV1X7MoZswh9gyRLetXYWImVX1BqIvP8KftulJg/wIA==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.8.3:
-    resolution: {integrity: sha512-vxMDXwaOjweW/4etY7BxrXCSkvtwh0PbwVafyfT1Ww659SedUxd5rM3V2ZCmbwG8NiCfY7d6VtxyHx3Wh1GoZA==}
+  turbo-linux-64@2.8.9:
+    resolution: {integrity: sha512-OXC9HdCtsHvyH+5KUoH8ds+p5WU13vdif0OPbsFzZca4cUXMwKA3HWwUuCgQetk0iAE4cscXpi/t8A263n3VTg==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.8.3:
-    resolution: {integrity: sha512-mQX7uYBZFkuPLLlKaNe9IjR1JIef4YvY8f21xFocvttXvdPebnq3PK1Zjzl9A1zun2BEuWNUwQIL8lgvN9Pm3Q==}
+  turbo-linux-arm64@2.8.9:
+    resolution: {integrity: sha512-yI5n8jNXiFA6+CxnXG0gO7h5ZF1+19K8uO3/kXPQmyl37AdiA7ehKJQOvf9OPAnmkGDHcF2HSCPltabERNRmug==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.8.3:
-    resolution: {integrity: sha512-YLGEfppGxZj3VWcNOVa08h6ISsVKiG85aCAWosOKNUjb6yErWEuydv6/qImRJUI+tDLvDvW7BxopAkujRnWCrw==}
+  turbo-windows-64@2.8.9:
+    resolution: {integrity: sha512-/OztzeGftJAg258M/9vK2ZCkUKUzqrWXJIikiD2pm8TlqHcIYUmepDbyZSDfOiUjMy6NzrLFahpNLnY7b5vNgg==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.8.3:
-    resolution: {integrity: sha512-afTUGKBRmOJU1smQSBnFGcbq0iabAPwh1uXu2BVk7BREg30/1gMnJh9DFEQTah+UD3n3ru8V55J83RQNFfqoyw==}
+  turbo-windows-arm64@2.8.9:
+    resolution: {integrity: sha512-xZ2VTwVTjIqpFZKN4UBxDHCPM3oJ2J5cpRzCBSmRpJ/Pn33wpiYjs+9FB2E03svKaD04/lSSLlEUej0UYsugfg==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.8.3:
-    resolution: {integrity: sha512-8Osxz5Tu/Dw2kb31EAY+nhq/YZ3wzmQSmYa1nIArqxgCAldxv9TPlrAiaBUDVnKA4aiPn0OFBD1ACcpc5VFOAQ==}
+  turbo@2.8.9:
+    resolution: {integrity: sha512-G+Mq8VVQAlpz/0HTsxiNNk/xywaHGl+dk1oiBREgOEVCCDjXInDlONWUn5srRnC9s5tdHTFD1bx1N19eR4hI+g==}
     hasBin: true
 
   typescript@5.9.3:
@@ -1329,11 +1291,6 @@ packages:
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
-
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
   vite@7.3.1:
@@ -1376,26 +1333,32 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
-      '@types/debug':
+      '@opentelemetry/api':
         optional: true
       '@types/node':
         optional: true
-      '@vitest/browser':
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
         optional: true
       '@vitest/ui':
         optional: true
@@ -1425,39 +1388,39 @@ packages:
 
 snapshots:
 
-  '@biomejs/biome@1.9.4':
+  '@biomejs/biome@2.4.0':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.9.4
-      '@biomejs/cli-darwin-x64': 1.9.4
-      '@biomejs/cli-linux-arm64': 1.9.4
-      '@biomejs/cli-linux-arm64-musl': 1.9.4
-      '@biomejs/cli-linux-x64': 1.9.4
-      '@biomejs/cli-linux-x64-musl': 1.9.4
-      '@biomejs/cli-win32-arm64': 1.9.4
-      '@biomejs/cli-win32-x64': 1.9.4
+      '@biomejs/cli-darwin-arm64': 2.4.0
+      '@biomejs/cli-darwin-x64': 2.4.0
+      '@biomejs/cli-linux-arm64': 2.4.0
+      '@biomejs/cli-linux-arm64-musl': 2.4.0
+      '@biomejs/cli-linux-x64': 2.4.0
+      '@biomejs/cli-linux-x64-musl': 2.4.0
+      '@biomejs/cli-win32-arm64': 2.4.0
+      '@biomejs/cli-win32-x64': 2.4.0
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
+  '@biomejs/cli-darwin-arm64@2.4.0':
     optional: true
 
-  '@biomejs/cli-darwin-x64@1.9.4':
+  '@biomejs/cli-darwin-x64@2.4.0':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
+  '@biomejs/cli-linux-arm64-musl@2.4.0':
     optional: true
 
-  '@biomejs/cli-linux-arm64@1.9.4':
+  '@biomejs/cli-linux-arm64@2.4.0':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
+  '@biomejs/cli-linux-x64-musl@2.4.0':
     optional: true
 
-  '@biomejs/cli-linux-x64@1.9.4':
+  '@biomejs/cli-linux-x64@2.4.0':
     optional: true
 
-  '@biomejs/cli-win32-arm64@1.9.4':
+  '@biomejs/cli-win32-arm64@2.4.0':
     optional: true
 
-  '@biomejs/cli-win32-x64@1.9.4':
+  '@biomejs/cli-win32-x64@2.4.0':
     optional: true
 
   '@esbuild/aix-ppc64@0.27.3':
@@ -1544,128 +1507,128 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@25.2.2)':
+  '@inquirer/checkbox@4.3.2(@types/node@25.2.3)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@25.2.2)
+      '@inquirer/core': 10.3.2(@types/node@25.2.3)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.2.2)
+      '@inquirer/type': 3.0.10(@types/node@25.2.3)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.2.2
+      '@types/node': 25.2.3
 
-  '@inquirer/confirm@5.1.21(@types/node@25.2.2)':
+  '@inquirer/confirm@5.1.21(@types/node@25.2.3)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.2.2)
-      '@inquirer/type': 3.0.10(@types/node@25.2.2)
+      '@inquirer/core': 10.3.2(@types/node@25.2.3)
+      '@inquirer/type': 3.0.10(@types/node@25.2.3)
     optionalDependencies:
-      '@types/node': 25.2.2
+      '@types/node': 25.2.3
 
-  '@inquirer/core@10.3.2(@types/node@25.2.2)':
+  '@inquirer/core@10.3.2(@types/node@25.2.3)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.2.2)
+      '@inquirer/type': 3.0.10(@types/node@25.2.3)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.2.2
+      '@types/node': 25.2.3
 
-  '@inquirer/editor@4.2.23(@types/node@25.2.2)':
+  '@inquirer/editor@4.2.23(@types/node@25.2.3)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.2.2)
-      '@inquirer/external-editor': 1.0.3(@types/node@25.2.2)
-      '@inquirer/type': 3.0.10(@types/node@25.2.2)
+      '@inquirer/core': 10.3.2(@types/node@25.2.3)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.2.3)
+      '@inquirer/type': 3.0.10(@types/node@25.2.3)
     optionalDependencies:
-      '@types/node': 25.2.2
+      '@types/node': 25.2.3
 
-  '@inquirer/expand@4.0.23(@types/node@25.2.2)':
+  '@inquirer/expand@4.0.23(@types/node@25.2.3)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.2.2)
-      '@inquirer/type': 3.0.10(@types/node@25.2.2)
+      '@inquirer/core': 10.3.2(@types/node@25.2.3)
+      '@inquirer/type': 3.0.10(@types/node@25.2.3)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.2.2
+      '@types/node': 25.2.3
 
-  '@inquirer/external-editor@1.0.3(@types/node@25.2.2)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.2.3)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 25.2.2
+      '@types/node': 25.2.3
 
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/input@4.3.1(@types/node@25.2.2)':
+  '@inquirer/input@4.3.1(@types/node@25.2.3)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.2.2)
-      '@inquirer/type': 3.0.10(@types/node@25.2.2)
+      '@inquirer/core': 10.3.2(@types/node@25.2.3)
+      '@inquirer/type': 3.0.10(@types/node@25.2.3)
     optionalDependencies:
-      '@types/node': 25.2.2
+      '@types/node': 25.2.3
 
-  '@inquirer/number@3.0.23(@types/node@25.2.2)':
+  '@inquirer/number@3.0.23(@types/node@25.2.3)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.2.2)
-      '@inquirer/type': 3.0.10(@types/node@25.2.2)
+      '@inquirer/core': 10.3.2(@types/node@25.2.3)
+      '@inquirer/type': 3.0.10(@types/node@25.2.3)
     optionalDependencies:
-      '@types/node': 25.2.2
+      '@types/node': 25.2.3
 
-  '@inquirer/password@4.0.23(@types/node@25.2.2)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@25.2.2)
-      '@inquirer/type': 3.0.10(@types/node@25.2.2)
-    optionalDependencies:
-      '@types/node': 25.2.2
-
-  '@inquirer/prompts@7.10.1(@types/node@25.2.2)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@25.2.2)
-      '@inquirer/confirm': 5.1.21(@types/node@25.2.2)
-      '@inquirer/editor': 4.2.23(@types/node@25.2.2)
-      '@inquirer/expand': 4.0.23(@types/node@25.2.2)
-      '@inquirer/input': 4.3.1(@types/node@25.2.2)
-      '@inquirer/number': 3.0.23(@types/node@25.2.2)
-      '@inquirer/password': 4.0.23(@types/node@25.2.2)
-      '@inquirer/rawlist': 4.1.11(@types/node@25.2.2)
-      '@inquirer/search': 3.2.2(@types/node@25.2.2)
-      '@inquirer/select': 4.4.2(@types/node@25.2.2)
-    optionalDependencies:
-      '@types/node': 25.2.2
-
-  '@inquirer/rawlist@4.1.11(@types/node@25.2.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.2.2)
-      '@inquirer/type': 3.0.10(@types/node@25.2.2)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 25.2.2
-
-  '@inquirer/search@3.2.2(@types/node@25.2.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.2.2)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.2.2)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 25.2.2
-
-  '@inquirer/select@4.4.2(@types/node@25.2.2)':
+  '@inquirer/password@4.0.23(@types/node@25.2.3)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@25.2.2)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.2.2)
+      '@inquirer/core': 10.3.2(@types/node@25.2.3)
+      '@inquirer/type': 3.0.10(@types/node@25.2.3)
+    optionalDependencies:
+      '@types/node': 25.2.3
+
+  '@inquirer/prompts@7.10.1(@types/node@25.2.3)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@25.2.3)
+      '@inquirer/confirm': 5.1.21(@types/node@25.2.3)
+      '@inquirer/editor': 4.2.23(@types/node@25.2.3)
+      '@inquirer/expand': 4.0.23(@types/node@25.2.3)
+      '@inquirer/input': 4.3.1(@types/node@25.2.3)
+      '@inquirer/number': 3.0.23(@types/node@25.2.3)
+      '@inquirer/password': 4.0.23(@types/node@25.2.3)
+      '@inquirer/rawlist': 4.1.11(@types/node@25.2.3)
+      '@inquirer/search': 3.2.2(@types/node@25.2.3)
+      '@inquirer/select': 4.4.2(@types/node@25.2.3)
+    optionalDependencies:
+      '@types/node': 25.2.3
+
+  '@inquirer/rawlist@4.1.11(@types/node@25.2.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.2.3)
+      '@inquirer/type': 3.0.10(@types/node@25.2.3)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.2.2
+      '@types/node': 25.2.3
 
-  '@inquirer/type@3.0.10(@types/node@25.2.2)':
+  '@inquirer/search@3.2.2(@types/node@25.2.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.2.3)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.2.3)
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 25.2.2
+      '@types/node': 25.2.3
+
+  '@inquirer/select@4.4.2(@types/node@25.2.3)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@25.2.3)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.2.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 25.2.3
+
+  '@inquirer/type@3.0.10(@types/node@25.2.3)':
+    optionalDependencies:
+      '@types/node': 25.2.3
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -1910,6 +1873,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.57.1':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -1926,57 +1891,54 @@ snapshots:
 
   '@types/js-yaml@4.0.9': {}
 
-  '@types/node@25.2.2':
+  '@types/node@25.2.3':
     dependencies:
       undici-types: 7.16.0
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 25.2.2
+      '@types/node': 25.2.3
 
   '@types/uuid@10.0.0': {}
 
-  '@vitest/expect@3.2.4':
+  '@vitest/expect@4.0.18':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.2.2))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.2.3))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.2.2)
+      vite: 7.3.1(@types/node@25.2.3)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/pretty-format@4.0.18':
     dependencies:
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.0.3
 
-  '@vitest/runner@3.2.4':
+  '@vitest/runner@4.0.18':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 4.0.18
       pathe: 2.0.3
-      strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.4':
+  '@vitest/snapshot@4.0.18':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 4.0.18
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.4':
-    dependencies:
-      tinyspy: 4.0.4
+  '@vitest/spy@4.0.18': {}
 
-  '@vitest/utils@3.2.4':
+  '@vitest/utils@4.0.18':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
 
   ajv@8.17.1:
     dependencies:
@@ -1999,21 +1961,11 @@ snapshots:
 
   before-after-hook@3.0.2: {}
 
-  cac@6.7.14: {}
-
-  chai@5.3.3:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.3
-      deep-eql: 5.0.2
-      loupe: 3.2.1
-      pathval: 2.0.1
+  chai@6.2.2: {}
 
   chalk@5.6.2: {}
 
   chardet@2.1.1: {}
-
-  check-error@2.1.3: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -2030,12 +1982,6 @@ snapshots:
   color-name@1.1.4: {}
 
   commander@13.1.0: {}
-
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
-
-  deep-eql@5.0.2: {}
 
   emoji-regex@10.6.0: {}
 
@@ -2103,17 +2049,17 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  inquirer@12.11.1(@types/node@25.2.2):
+  inquirer@12.11.1(@types/node@25.2.3):
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@25.2.2)
-      '@inquirer/prompts': 7.10.1(@types/node@25.2.2)
-      '@inquirer/type': 3.0.10(@types/node@25.2.2)
+      '@inquirer/core': 10.3.2(@types/node@25.2.3)
+      '@inquirer/prompts': 7.10.1(@types/node@25.2.3)
+      '@inquirer/type': 3.0.10(@types/node@25.2.3)
       mute-stream: 2.0.0
       run-async: 4.0.6
       rxjs: 7.8.2
     optionalDependencies:
-      '@types/node': 25.2.2
+      '@types/node': 25.2.3
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -2130,8 +2076,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  js-tokens@9.0.1: {}
-
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -2145,15 +2089,11 @@ snapshots:
 
   long@5.3.2: {}
 
-  loupe@3.2.1: {}
-
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   mimic-function@5.0.1: {}
-
-  ms@2.1.3: {}
 
   mute-stream@2.0.0: {}
 
@@ -2162,6 +2102,8 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  obug@2.1.1: {}
 
   onetime@7.0.0:
     dependencies:
@@ -2180,8 +2122,6 @@ snapshots:
       strip-ansi: 7.1.2
 
   pathe@2.0.3: {}
-
-  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -2205,7 +2145,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 25.2.2
+      '@types/node': 25.2.3
       long: 5.3.2
 
   pure-rand@7.0.1: {}
@@ -2288,55 +2228,47 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
-  strip-literal@3.1.0:
-    dependencies:
-      js-tokens: 9.0.1
-
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.2: {}
+  tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  tinypool@1.1.1: {}
-
-  tinyrainbow@2.0.0: {}
-
-  tinyspy@4.0.4: {}
+  tinyrainbow@3.0.3: {}
 
   tr46@0.0.3: {}
 
   tslib@2.8.1: {}
 
-  turbo-darwin-64@2.8.3:
+  turbo-darwin-64@2.8.9:
     optional: true
 
-  turbo-darwin-arm64@2.8.3:
+  turbo-darwin-arm64@2.8.9:
     optional: true
 
-  turbo-linux-64@2.8.3:
+  turbo-linux-64@2.8.9:
     optional: true
 
-  turbo-linux-arm64@2.8.3:
+  turbo-linux-arm64@2.8.9:
     optional: true
 
-  turbo-windows-64@2.8.3:
+  turbo-windows-64@2.8.9:
     optional: true
 
-  turbo-windows-arm64@2.8.3:
+  turbo-windows-arm64@2.8.9:
     optional: true
 
-  turbo@2.8.3:
+  turbo@2.8.9:
     optionalDependencies:
-      turbo-darwin-64: 2.8.3
-      turbo-darwin-arm64: 2.8.3
-      turbo-linux-64: 2.8.3
-      turbo-linux-arm64: 2.8.3
-      turbo-windows-64: 2.8.3
-      turbo-windows-arm64: 2.8.3
+      turbo-darwin-64: 2.8.9
+      turbo-darwin-arm64: 2.8.9
+      turbo-linux-64: 2.8.9
+      turbo-linux-arm64: 2.8.9
+      turbo-windows-64: 2.8.9
+      turbo-windows-arm64: 2.8.9
 
   typescript@5.9.3: {}
 
@@ -2348,28 +2280,7 @@ snapshots:
 
   uuid@11.1.0: {}
 
-  vite-node@3.2.4(@types/node@25.2.2):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.3.1(@types/node@25.2.2)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vite@7.3.1(@types/node@25.2.2):
+  vite@7.3.1(@types/node@25.2.3):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2378,36 +2289,34 @@ snapshots:
       rollup: 4.57.1
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.2.2
+      '@types/node': 25.2.3
       fsevents: 2.3.3
 
-  vitest@3.2.4(@types/node@25.2.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3):
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.2.2))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.3))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
       expect-type: 1.3.0
       magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.3
       std-env: 3.10.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
+      tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.2.2)
-      vite-node: 3.2.4(@types/node@25.2.2)
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@25.2.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.2.2
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.2.3
     transitivePeerDependencies:
       - jiti
       - less
@@ -2417,7 +2326,6 @@ snapshots:
       - sass-embedded
       - stylus
       - sugarss
-      - supports-color
       - terser
       - tsx
       - yaml


### PR DESCRIPTION
## Summary
- Bumps @biomejs/biome from 1.9.x to 2.4.x (major)
- Bumps vitest from 3.x to 4.x (major)
- Bumps turbo from 2.3.x to 2.8.x
- Bumps @types/node from 25.2.2 to 25.2.3

Supersedes #10 (dependabot PR that could not trigger CI after fixes).

## Test plan
- [x] pnpm build — 20 packages
- [x] pnpm test — 983 tests
- [x] pnpm typecheck
- [x] pnpm lint — 143 files, 0 errors

🤖 Generated with Claude Code