### PR TITLE
feat: daemon resilience, smart GitHub polling, dedup improvements (WQ-93/94/95)

### DIFF
--- a/connectors/github/src/__tests__/source.test.ts
+++ b/connectors/github/src/__tests__/source.test.ts
@@ -13,6 +13,7 @@ function createMockOctokit() {
 		list: vi.fn(),
 		listReviews: vi.fn(),
 		listReviewComments: vi.fn(),
+		listReviewCommentsForRepo: vi.fn(),
 	};
 	const issues = {
 		listCommentsForRepo: vi.fn(),
@@ -117,6 +118,7 @@ function makeReviewComment(overrides: Record<string, unknown> = {}) {
 		body: 'Needs a fix here',
 		updated_at: '2024-01-15T10:00:00Z',
 		html_url: 'https://github.com/owner/repo/pull/1#discussion_r200',
+		pull_request_url: 'https://api.github.com/repos/owner/repo/pulls/1',
 		diff_hunk: '@@ -1,3 +1,3 @@',
 		path: 'src/index.ts',
 		user: { login: 'bob', type: 'User' },
@@ -334,7 +336,7 @@ describe('GitHubSource', () => {
 			const comment = makeReviewComment();
 
 			mock.pulls.list.mockResolvedValue({ data: [pr] });
-			mock.pulls.listReviewComments.mockResolvedValue({ data: [comment] });
+			mock.pulls.listReviewCommentsForRepo.mockResolvedValue({ data: [comment] });
 
 			const source = await createSource(['pull_request_review_comment'], mock);
 			const result = await source.poll('2024-01-15T09:00:00Z');
@@ -355,7 +357,7 @@ describe('GitHubSource', () => {
 
 			mock.pulls.list.mockResolvedValue({ data: [pr] });
 			mock.pulls.listReviews.mockResolvedValue({ data: [review] });
-			mock.pulls.listReviewComments.mockResolvedValue({ data: [comment] });
+			mock.pulls.listReviewCommentsForRepo.mockResolvedValue({ data: [comment] });
 
 			const source = await createSource(
 				['pull_request.review_submitted', 'pull_request_review_comment'],

--- a/packages/core/src/__tests__/supervisor.test.ts
+++ b/packages/core/src/__tests__/supervisor.test.ts
@@ -1,0 +1,205 @@
+import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Supervisor } from '../supervisor.js';
+
+const SUPERVISOR_PID_FILE = join(homedir(), '.orgloop', 'supervisor.pid');
+
+describe('Supervisor', () => {
+	let supervisor: Supervisor;
+
+	afterEach(async () => {
+		if (supervisor) {
+			await supervisor.stop();
+		}
+		try {
+			await unlink(SUPERVISOR_PID_FILE);
+		} catch {
+			/* ignore */
+		}
+	});
+
+	it('initializes with default options', () => {
+		supervisor = new Supervisor({ modulePath: '/dev/null' });
+		const status = supervisor.status();
+		expect(status.running).toBe(false);
+		expect(status.childPid).toBeNull();
+		expect(status.restartCount).toBe(0);
+		expect(status.crashLoopDetected).toBe(false);
+	});
+
+	it('accepts custom options', () => {
+		supervisor = new Supervisor({
+			modulePath: '/dev/null',
+			maxRestarts: 5,
+			crashWindowMs: 60_000,
+			initialBackoffMs: 500,
+			maxBackoffMs: 10_000,
+			stableThresholdMs: 30_000,
+		});
+		expect(supervisor).toBeDefined();
+	});
+
+	it('reports status correctly when not started', () => {
+		supervisor = new Supervisor({ modulePath: '/dev/null' });
+		const status = supervisor.status();
+		expect(status).toEqual({
+			running: false,
+			childPid: null,
+			restartCount: 0,
+			lastExitCode: null,
+			lastExitSignal: null,
+			crashLoopDetected: false,
+		});
+	});
+
+	it('stop is safe to call when not started', async () => {
+		supervisor = new Supervisor({ modulePath: '/dev/null' });
+		await expect(supervisor.stop()).resolves.not.toThrow();
+	});
+
+	it('start is idempotent', async () => {
+		// Use a script that exits immediately to avoid blocking
+		const scriptPath = join(homedir(), '.orgloop', 'test-supervisor-noop.mjs');
+		await mkdir(join(homedir(), '.orgloop'), { recursive: true });
+		await writeFile(scriptPath, 'process.exit(0);', 'utf-8');
+
+		supervisor = new Supervisor({
+			modulePath: scriptPath,
+			env: {},
+		});
+
+		await supervisor.start();
+		// Second start should be no-op
+		await supervisor.start();
+
+		expect(supervisor.status().running).toBe(true);
+
+		await supervisor.stop();
+
+		try {
+			await unlink(scriptPath);
+		} catch {
+			/* ignore */
+		}
+	});
+
+	it('writes supervisor PID file on start', async () => {
+		const scriptPath = join(homedir(), '.orgloop', 'test-supervisor-pid.mjs');
+		await mkdir(join(homedir(), '.orgloop'), { recursive: true });
+		await writeFile(scriptPath, 'setTimeout(() => {}, 60000);', 'utf-8');
+
+		supervisor = new Supervisor({
+			modulePath: scriptPath,
+			env: {},
+		});
+
+		await supervisor.start();
+
+		const pidContent = await readFile(SUPERVISOR_PID_FILE, 'utf-8');
+		expect(Number.parseInt(pidContent, 10)).toBe(process.pid);
+
+		await supervisor.stop();
+
+		try {
+			await unlink(scriptPath);
+		} catch {
+			/* ignore */
+		}
+	});
+
+	it('detects crash loop after max restarts', async () => {
+		const scriptPath = join(homedir(), '.orgloop', 'test-supervisor-crash.mjs');
+		await mkdir(join(homedir(), '.orgloop'), { recursive: true });
+		await writeFile(scriptPath, 'process.exit(1);', 'utf-8');
+
+		const logs: string[] = [];
+		let crashLoopCalled = false;
+
+		supervisor = new Supervisor({
+			modulePath: scriptPath,
+			env: {},
+			maxRestarts: 3,
+			crashWindowMs: 60_000,
+			initialBackoffMs: 10,
+			maxBackoffMs: 50,
+			stableThresholdMs: 1_000,
+		});
+
+		supervisor.onLog = (msg) => logs.push(msg);
+		supervisor.onCrashLoop = () => {
+			crashLoopCalled = true;
+		};
+
+		await supervisor.start();
+
+		// Wait for crash loop detection (3 restarts × ~50ms backoff + exit time)
+		await new Promise((resolve) => setTimeout(resolve, 2_000));
+
+		expect(crashLoopCalled).toBe(true);
+		expect(supervisor.status().crashLoopDetected).toBe(true);
+		expect(supervisor.status().restartCount).toBeGreaterThanOrEqual(3);
+
+		try {
+			await unlink(scriptPath);
+		} catch {
+			/* ignore */
+		}
+	});
+
+	it('tracks exit codes and signals', async () => {
+		const scriptPath = join(homedir(), '.orgloop', 'test-supervisor-exit.mjs');
+		await mkdir(join(homedir(), '.orgloop'), { recursive: true });
+		await writeFile(scriptPath, 'process.exit(42);', 'utf-8');
+
+		supervisor = new Supervisor({
+			modulePath: scriptPath,
+			env: {},
+			maxRestarts: 1,
+			initialBackoffMs: 10,
+			maxBackoffMs: 50,
+			crashWindowMs: 60_000,
+		});
+
+		await supervisor.start();
+
+		// Wait for exit
+		await new Promise((resolve) => setTimeout(resolve, 500));
+
+		const status = supervisor.status();
+		expect(status.lastExitCode).toBe(42);
+
+		try {
+			await unlink(scriptPath);
+		} catch {
+			/* ignore */
+		}
+	});
+
+	it('stops cleanly after child exits', async () => {
+		const scriptPath = join(homedir(), '.orgloop', 'test-supervisor-clean.mjs');
+		await mkdir(join(homedir(), '.orgloop'), { recursive: true });
+		await writeFile(scriptPath, 'process.exit(0);', 'utf-8');
+
+		supervisor = new Supervisor({
+			modulePath: scriptPath,
+			env: {},
+		});
+
+		await supervisor.start();
+
+		// Wait for child to exit cleanly
+		await new Promise((resolve) => setTimeout(resolve, 500));
+
+		// Clean exit (code 0) should stop the supervisor
+		expect(supervisor.status().running).toBe(false);
+		expect(supervisor.status().lastExitCode).toBe(0);
+
+		try {
+			await unlink(scriptPath);
+		} catch {
+			/* ignore */
+		}
+	});
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,9 @@ export {
 	InMemoryCheckpointStore,
 	InMemoryEventStore,
 } from './store.js';
+export type { SupervisorOptions, SupervisorStatus } from './supervisor.js';
+// Supervisor
+export { Supervisor } from './supervisor.js';
 export type { TransformPipelineOptions, TransformPipelineResult } from './transform.js';
 // Transform pipeline
 export { executeTransformPipeline } from './transform.js';

--- a/packages/core/src/supervisor.ts
+++ b/packages/core/src/supervisor.ts
@@ -1,0 +1,251 @@
+/**
+ * Supervisor — restarts the daemon child process on abnormal exit.
+ *
+ * Exponential backoff with crash loop detection. Forwards signals
+ * to the child and cleans up on shutdown.
+ */
+
+import type { ChildProcess } from 'node:child_process';
+import { fork } from 'node:child_process';
+import { mkdir, unlink, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const SUPERVISOR_DIR = join(homedir(), '.orgloop');
+const SUPERVISOR_PID_FILE = join(SUPERVISOR_DIR, 'supervisor.pid');
+
+export interface SupervisorOptions {
+	/** Path to the module to fork (the start.ts file) */
+	modulePath: string;
+	/** Environment variables for the child */
+	env?: Record<string, string>;
+	/** Log file descriptors: [stdout fd, stderr fd] */
+	stdio?: [number, number];
+	/** Max restarts within the crash window before giving up (default: 10) */
+	maxRestarts?: number;
+	/** Crash window in ms — resets restart count after stable running (default: 300_000 = 5m) */
+	crashWindowMs?: number;
+	/** Initial backoff delay in ms (default: 1000) */
+	initialBackoffMs?: number;
+	/** Maximum backoff delay in ms (default: 30_000) */
+	maxBackoffMs?: number;
+	/** Stable running threshold — reset backoff after this many ms of uptime (default: 60_000) */
+	stableThresholdMs?: number;
+}
+
+export interface SupervisorStatus {
+	running: boolean;
+	childPid: number | null;
+	restartCount: number;
+	lastExitCode: number | null;
+	lastExitSignal: string | null;
+	crashLoopDetected: boolean;
+}
+
+export class Supervisor {
+	private child: ChildProcess | null = null;
+	private running = false;
+	private shuttingDown = false;
+	private restartCount = 0;
+	private windowRestartCount = 0;
+	private windowStartTime = 0;
+	private lastChildStart = 0;
+	private currentBackoffMs: number;
+	private restartTimer: ReturnType<typeof setTimeout> | null = null;
+	private lastExitCode: number | null = null;
+	private lastExitSignal: string | null = null;
+	private crashLoopDetected = false;
+
+	private readonly modulePath: string;
+	private readonly env: Record<string, string>;
+	private readonly stdioFds: [number, number] | null;
+	private readonly maxRestarts: number;
+	private readonly crashWindowMs: number;
+	private readonly initialBackoffMs: number;
+	private readonly maxBackoffMs: number;
+	private readonly stableThresholdMs: number;
+
+	/** Callback for logging — set by consumer */
+	onLog: ((message: string) => void) | null = null;
+	/** Callback when crash loop detected */
+	onCrashLoop: (() => void) | null = null;
+
+	constructor(options: SupervisorOptions) {
+		this.modulePath = options.modulePath;
+		this.env = options.env ?? {};
+		this.stdioFds = options.stdio ?? null;
+		this.maxRestarts = options.maxRestarts ?? 10;
+		this.crashWindowMs = options.crashWindowMs ?? 300_000;
+		this.initialBackoffMs = options.initialBackoffMs ?? 1_000;
+		this.maxBackoffMs = options.maxBackoffMs ?? 30_000;
+		this.stableThresholdMs = options.stableThresholdMs ?? 60_000;
+		this.currentBackoffMs = this.initialBackoffMs;
+	}
+
+	async start(): Promise<void> {
+		if (this.running) return;
+		this.running = true;
+		this.shuttingDown = false;
+		this.crashLoopDetected = false;
+		this.restartCount = 0;
+		this.windowRestartCount = 0;
+		this.windowStartTime = Date.now();
+		this.currentBackoffMs = this.initialBackoffMs;
+
+		// Write supervisor PID
+		await mkdir(SUPERVISOR_DIR, { recursive: true });
+		await writeFile(SUPERVISOR_PID_FILE, String(process.pid), 'utf-8');
+
+		this.spawnChild();
+	}
+
+	async stop(): Promise<void> {
+		if (!this.running) return;
+		this.shuttingDown = true;
+		this.running = false;
+
+		if (this.restartTimer) {
+			clearTimeout(this.restartTimer);
+			this.restartTimer = null;
+		}
+
+		if (this.child && this.child.exitCode === null) {
+			// Send SIGTERM to child
+			this.child.kill('SIGTERM');
+
+			// Wait up to 5s for graceful exit
+			await new Promise<void>((resolve) => {
+				const timeout = setTimeout(() => {
+					if (this.child && this.child.exitCode === null) {
+						this.child.kill('SIGKILL');
+					}
+					resolve();
+				}, 5_000);
+
+				if (this.child) {
+					this.child.once('exit', () => {
+						clearTimeout(timeout);
+						resolve();
+					});
+				} else {
+					clearTimeout(timeout);
+					resolve();
+				}
+			});
+		}
+
+		// Clean up supervisor PID file
+		try {
+			await unlink(SUPERVISOR_PID_FILE);
+		} catch {
+			/* ignore */
+		}
+	}
+
+	status(): SupervisorStatus {
+		return {
+			running: this.running,
+			childPid: this.child?.pid ?? null,
+			restartCount: this.restartCount,
+			lastExitCode: this.lastExitCode,
+			lastExitSignal: this.lastExitSignal,
+			crashLoopDetected: this.crashLoopDetected,
+		};
+	}
+
+	private spawnChild(): void {
+		const stdio = this.stdioFds
+			? ['ignore' as const, this.stdioFds[0], this.stdioFds[1], 'ipc' as const]
+			: ['ignore' as const, 'inherit' as const, 'inherit' as const, 'ipc' as const];
+
+		this.child = fork(this.modulePath, [], {
+			detached: false,
+			stdio,
+			env: {
+				...process.env,
+				...this.env,
+				ORGLOOP_DAEMON: '1',
+				ORGLOOP_SUPERVISED: '1',
+			},
+		});
+
+		this.lastChildStart = Date.now();
+
+		this.child.on('exit', (code, signal) => {
+			this.lastExitCode = code;
+			this.lastExitSignal = signal;
+			this.handleChildExit(code, signal);
+		});
+
+		this.child.on('error', (err) => {
+			this.log(`Child process error: ${err.message}`);
+		});
+
+		// Disconnect IPC so child can run independently
+		if (this.child.connected) {
+			this.child.disconnect();
+		}
+	}
+
+	private handleChildExit(code: number | null, signal: string | null): void {
+		if (this.shuttingDown) {
+			this.log('Child exited during shutdown');
+			return;
+		}
+
+		if (code === 0) {
+			this.log('Child exited cleanly (code 0)');
+			this.running = false;
+			return;
+		}
+
+		// Abnormal exit — consider restart
+		this.log(`Child exited abnormally (code=${code}, signal=${signal})`);
+
+		// Check if child ran long enough to be considered stable
+		const uptime = Date.now() - this.lastChildStart;
+		if (uptime >= this.stableThresholdMs) {
+			// Reset backoff — child was stable before crashing
+			this.currentBackoffMs = this.initialBackoffMs;
+			this.windowRestartCount = 0;
+			this.windowStartTime = Date.now();
+		}
+
+		// Check crash window
+		if (Date.now() - this.windowStartTime > this.crashWindowMs) {
+			// Window expired, reset counter
+			this.windowRestartCount = 0;
+			this.windowStartTime = Date.now();
+		}
+
+		this.windowRestartCount++;
+		this.restartCount++;
+
+		if (this.windowRestartCount >= this.maxRestarts) {
+			this.crashLoopDetected = true;
+			this.running = false;
+			this.log(
+				`Crash loop detected: ${this.windowRestartCount} restarts in ${Math.round(this.crashWindowMs / 1000)}s window. Giving up.`,
+			);
+			this.onCrashLoop?.();
+			return;
+		}
+
+		// Schedule restart with backoff
+		this.log(`Restarting in ${this.currentBackoffMs}ms (attempt ${this.restartCount})`);
+
+		this.restartTimer = setTimeout(() => {
+			this.restartTimer = null;
+			if (this.running && !this.shuttingDown) {
+				this.spawnChild();
+			}
+		}, this.currentBackoffMs);
+
+		// Exponential backoff
+		this.currentBackoffMs = Math.min(this.currentBackoffMs * 2, this.maxBackoffMs);
+	}
+
+	private log(message: string): void {
+		this.onLog?.(`[supervisor] ${message}`);
+	}
+}

--- a/transforms/dedup/src/index.ts
+++ b/transforms/dedup/src/index.ts
@@ -33,6 +33,11 @@ export function register(): TransformRegistration {
 					description: 'Storage backend (only "memory" for MVP).',
 					default: 'memory',
 				},
+				track_delivery: {
+					type: 'boolean',
+					description: 'Track delivery stats (seen vs delivered vs dropped).',
+					default: false,
+				},
 			},
 			required: ['window'],
 			additionalProperties: false,
@@ -40,4 +45,5 @@ export function register(): TransformRegistration {
 	};
 }
 
+export type { DedupStats } from './dedup.js';
 export { DedupTransform } from './dedup.js';


### PR DESCRIPTION
## Summary

Three urgent improvements to OrgLoop stability and efficiency.

### WQ-93: Daemon Resilience
- **Supervisor** class with exponential backoff (1s→30s cap), crash loop detection (10 restarts in 5min)
- **Crash handlers** for `uncaughtException`/`unhandledRejection` → graceful shutdown with 5s timeout
- **Health heartbeat** — JSON to `~/.orgloop/heartbeat` every 30s; `orgloop status` can detect stale daemons
- `--supervised` flag wires supervisor into daemon mode
- 12 new tests

### WQ-94: GitHub Smart Polling
Root cause: connector was making O(n) API calls per poll (per-PR review + comment fetches), exhausting 5000 req/hr on large repos.
- **Repo-level review comments** — `listReviewCommentsForRepo` (1 call) replaces per-PR `listReviewComments` (N calls)
- **PR state cache** — tracks `updated_at`, skips unchanged PRs for reviews. 30-day eviction.
- **Rate budget gating** — non-essential polls skipped when quota low. Configurable via `rate_budget` (0-1).
- All 50 GitHub connector tests passing

### WQ-95: Dedup Architecture
- `DedupStats` interface + `getStats()` for observability (seen/dropped/delivered counts)
- `track_delivery` config option (foundation for delivery-aware dedup)
- FE-23 (Delivery Journal) and FE-24 (Daemon Supervisor) future extension docs
- 3 new dedup tests

## Test Results
- **1204 tests passing, 0 failures**
- Build: 21/21 packages
- Typecheck: 40/40 packages
- Lint: 0 errors