### PR TITLE
fix(cli): tweak init and readme for minimal webhook demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ Source -> [Transform] -> Route -> Actor
 
 ## Try It
 
-Set up a webhook source and a console logger, then route an event between them.
+Set up a webhook source, then send an event.
 
 ```bash
 npm install -g @orgloop/cli
-orgloop init    # select "webhook" when prompted for connectors
-cd my-org
+mkdir my-org && cd my-org
+orgloop init
 npm install
 orgloop start
 ```
@@ -41,12 +41,12 @@ orgloop start
 In another terminal, send an event:
 
 ```bash
-curl -X POST http://localhost:3000/webhook \
+curl -X POST http://localhost:4800/webhook/webhook \
   -H "Content-Type: application/json" \
   -d '{"type": "test", "message": "hello from orgloop"}'
 ```
 
-You should see the event flow through the system and appear in your console log. That's the core loop: source emits, route matches, actor delivers, logger observes.
+Run `orgloop logs` to see the event. That's the core loop: source emits, route matches, actor delivers, logger observes.
 
 ---
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -192,8 +192,16 @@ loggers:
 `;
 }
 
-function generateDefaultRouteYaml(): string {
-	return `apiVersion: orgloop/v1alpha1
+function generateRouteYaml(connectors: string[]): string {
+	if (connectors.length === 1 && connectors[0] === 'webhook') {
+		return `apiVersion: orgloop/v1alpha1
+kind: RouteGroup
+
+routes: []
+`;
+	}
+	if (connectors.includes('github') && connectors.includes('openclaw')) {
+		return `apiVersion: orgloop/v1alpha1
 kind: RouteGroup
 
 routes:
@@ -209,6 +217,12 @@ routes:
       actor: openclaw-engineering-agent
     with:
       prompt_file: ../sops/example.md
+`;
+	}
+	return `apiVersion: orgloop/v1alpha1
+kind: RouteGroup
+
+routes: []
 `;
 }
 
@@ -365,7 +379,7 @@ async function scaffoldProject(
 
 	// Route files
 	const routePath = join(targetDir, 'routes', 'example.yaml');
-	await writeFile(routePath, generateDefaultRouteYaml(), 'utf-8');
+	await writeFile(routePath, generateRouteYaml(connectors), 'utf-8');
 	created.push('routes/example.yaml');
 
 	// Logger files
@@ -579,7 +593,7 @@ export function registerInitCommand(program: Command): void {
 							choices: AVAILABLE_CONNECTORS.map((c) => ({
 								name: c.charAt(0).toUpperCase() + c.slice(1),
 								value: c,
-								checked: ['github', 'linear', 'openclaw', 'claude-code'].includes(c),
+								checked: c === 'webhook',
 							})),
 						},
 					]);


### PR DESCRIPTION
## Summary

Fixes the minimal webhook demo so the README "Try It" flow works end-to-end. `orgloop init` with only webhook selected no longer fails doctor, and the README setup and curl commands are corrected.

## Changes Made

- **init**: Generate routes based on selected connectors — empty routes when only webhook; full example route when both github and openclaw are selected
- **init**: Default connector selection to webhook instead of github/linear/openclaw/claude-code
- **README**: Correct Try It setup (mkdir + cd before init)
- **README**: Correct curl port (4800) and path (`/webhook/webhook`)
- **README**: Mention using `orgloop logs` to view events

## Testing

- [x] Tests pass locally (`pnpm test`)
- [x] Linting passes (`pnpm run lint`)
- [x] TypeScript compiles (`pnpm typecheck`)
- [x] Manually verified using `orgloop-local` alias (`alias orgloop-local='node packages/cli/dist/index.js'`): `pnpm build`, then `orgloop-local init` (webhook), `npm install`, `orgloop-local start`, curl POST to webhook

---

- [x] I used AI tools to help write this PR