### PR TITLE
fix: update docs site GitHub URL to orgloop org

### DIFF
--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -13,7 +13,7 @@ When that actor finishes, its completion fires an event back into the system, an
 
 > You don't need reliable actors if you have a reliable system around them.
 
-[Get Started](/start/getting-started/) | [View on GitHub](https://github.com/c-h-/orgloop)
+[Get Started](/start/getting-started/) | [View on GitHub](https://github.com/orgloop/orgloop)
 
 ## Try It Now
 


### PR DESCRIPTION
Updates the remaining `c-h-/orgloop` reference on the docs site index page to `orgloop/orgloop`.