### PR TITLE
fix(connector-github): include review_id in PR review events for dedup

### DIFF
--- a/connectors/github/src/normalizer.ts
+++ b/connectors/github/src/normalizer.ts
@@ -42,10 +42,12 @@ export function normalizePullRequestReview(
 			repo: (repo.full_name as string) ?? '',
 			pr_number: pr.number as number,
 			url: (review.html_url as string) ?? '',
+			review_id: review.id as number,
 			review_state: review.state as string,
 		},
 		payload: {
 			action: 'review_submitted',
+			review_id: review.id,
 			review_state: review.state,
 			review_body: review.body,
 			pr_title: pr.title,


### PR DESCRIPTION
Includes review_id in PR review event dedup keys to prevent duplicate event processing when multiple reviews exist on the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)