### PR TITLE
feat: multi-module single daemon runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,8 @@ The `Runtime` owns the shared infrastructure (bus, scheduler, loggers, HTTP serv
 | `ModuleInstance` | `packages/core/src/module-instance.ts` | Per-module resource container. Sources, actors, transforms, lifecycle (loading/active/unloading/removed). |
 | `ModuleRegistry` | `packages/core/src/registry.ts` | Singleton module name registry. Prevents conflicts. |
 | `OrgLoop` | `packages/core/src/engine.ts` | Backward-compatible wrapper around Runtime. Single-module convenience API. |
+| Daemon Client | `packages/cli/src/daemon-client.ts` | HTTP client for communicating with a running daemon's control API. |
+| Module Registry (CLI) | `packages/cli/src/module-registry.ts` | Persistent module tracking (`~/.orgloop/modules.json`). Maps directories to loaded modules across CLI commands. |
 | `matchRoutes()` | `packages/core/src/router.ts` | Dot-path filtering, multi-route matching |
 | `executeTransformPipeline()` | `packages/core/src/transform.ts` | Sequential transforms, fail-open default |
 | `Scheduler` | `packages/core/src/scheduler.ts` | Poll intervals, graceful start/stop |
@@ -179,6 +181,8 @@ Every plugin type (connector, transform, logger) must be wired through the **ful
 | Runtime lifecycle (multi-module, shared infra) | `packages/core/src/__tests__/runtime.test.ts` | 11 |
 | Module registry (name conflicts, lookup) | `packages/core/src/__tests__/registry.test.ts` | 8 |
 | Module instance (lifecycle states, resource ownership) | `packages/core/src/__tests__/module-instance.test.ts` | 17 |
+| Multi-module runtime (load, unload, reload, events) | `packages/core/src/__tests__/multi-module-runtime.test.ts` | 9 |
+| Module registry CLI (persist, find, clear) | `packages/cli/src/__tests__/module-registry.test.ts` | 12 |
 
 When fixing a bug, add a regression test. When wiring a new plugin, add an engine-integration test.
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ loggers:
 - **Transforms for security** -- injection scanning, bot noise filtering, rate limiting
 - **Full observability** -- every event, transform, delivery logged and traceable
 - **One process replaces N pollers** -- no more scattered LaunchAgents and cron jobs
+- **Multi-module daemon** -- multiple projects share one daemon; add/remove modules without restarts
 - **Daemon mode** -- supervised background process with auto-restart
 - **`plan` before `start`** -- see exactly what will change (Terraform-style)
 

--- a/packages/cli/src/__tests__/module-registry.test.ts
+++ b/packages/cli/src/__tests__/module-registry.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for the module registry — persistent tracking of modules loaded
+ * into the running daemon.
+ */
+
+import { mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	clearModulesState,
+	deriveModuleName,
+	findModuleByDir,
+	findModuleByName,
+	readModulesState,
+	registerModule,
+	unregisterModule,
+	writeModulesState,
+} from '../module-registry.js';
+
+describe('module-registry', () => {
+	let testDir: string;
+	let originalHome: string;
+
+	beforeEach(async () => {
+		testDir = join(
+			tmpdir(),
+			`orgloop-modreg-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		await mkdir(join(testDir, '.orgloop'), { recursive: true });
+		originalHome = process.env.HOME ?? '';
+		process.env.HOME = testDir;
+	});
+
+	afterEach(async () => {
+		process.env.HOME = originalHome;
+		await rm(testDir, { recursive: true, force: true });
+	});
+
+	it('reads empty state when no file exists', async () => {
+		const state = await readModulesState();
+		expect(state).toEqual({ modules: [] });
+	});
+
+	it('writes and reads module state', async () => {
+		const state = {
+			modules: [
+				{
+					name: 'test-mod',
+					sourceDir: '/tmp/test-project',
+					configPath: '/tmp/test-project/orgloop.yaml',
+					loadedAt: '2026-01-01T00:00:00.000Z',
+				},
+			],
+		};
+		await writeModulesState(state);
+		const read = await readModulesState();
+		expect(read).toEqual(state);
+	});
+
+	it('registers a module', async () => {
+		await registerModule({
+			name: 'mod-a',
+			sourceDir: '/projects/a',
+			configPath: '/projects/a/orgloop.yaml',
+			loadedAt: '2026-01-01T00:00:00.000Z',
+		});
+
+		const state = await readModulesState();
+		expect(state.modules).toHaveLength(1);
+		expect(state.modules[0].name).toBe('mod-a');
+	});
+
+	it('replaces module with same name on re-register', async () => {
+		await registerModule({
+			name: 'mod-a',
+			sourceDir: '/projects/a',
+			configPath: '/projects/a/orgloop.yaml',
+			loadedAt: '2026-01-01T00:00:00.000Z',
+		});
+		await registerModule({
+			name: 'mod-a',
+			sourceDir: '/projects/a-new',
+			configPath: '/projects/a-new/orgloop.yaml',
+			loadedAt: '2026-01-02T00:00:00.000Z',
+		});
+
+		const state = await readModulesState();
+		expect(state.modules).toHaveLength(1);
+		expect(state.modules[0].sourceDir).toBe('/projects/a-new');
+	});
+
+	it('replaces module with same sourceDir on re-register', async () => {
+		await registerModule({
+			name: 'mod-a',
+			sourceDir: '/projects/a',
+			configPath: '/projects/a/orgloop.yaml',
+			loadedAt: '2026-01-01T00:00:00.000Z',
+		});
+		await registerModule({
+			name: 'mod-a-renamed',
+			sourceDir: '/projects/a',
+			configPath: '/projects/a/orgloop.yaml',
+			loadedAt: '2026-01-02T00:00:00.000Z',
+		});
+
+		const state = await readModulesState();
+		expect(state.modules).toHaveLength(1);
+		expect(state.modules[0].name).toBe('mod-a-renamed');
+	});
+
+	it('registers multiple modules', async () => {
+		await registerModule({
+			name: 'mod-a',
+			sourceDir: '/projects/a',
+			configPath: '/projects/a/orgloop.yaml',
+			loadedAt: '2026-01-01T00:00:00.000Z',
+		});
+		await registerModule({
+			name: 'mod-b',
+			sourceDir: '/projects/b',
+			configPath: '/projects/b/orgloop.yaml',
+			loadedAt: '2026-01-01T00:00:00.000Z',
+		});
+
+		const state = await readModulesState();
+		expect(state.modules).toHaveLength(2);
+	});
+
+	it('unregisters a module by name', async () => {
+		await registerModule({
+			name: 'mod-a',
+			sourceDir: '/projects/a',
+			configPath: '/projects/a/orgloop.yaml',
+			loadedAt: '2026-01-01T00:00:00.000Z',
+		});
+		await registerModule({
+			name: 'mod-b',
+			sourceDir: '/projects/b',
+			configPath: '/projects/b/orgloop.yaml',
+			loadedAt: '2026-01-01T00:00:00.000Z',
+		});
+
+		await unregisterModule('mod-a');
+
+		const state = await readModulesState();
+		expect(state.modules).toHaveLength(1);
+		expect(state.modules[0].name).toBe('mod-b');
+	});
+
+	it('finds module by directory', async () => {
+		await registerModule({
+			name: 'mod-a',
+			sourceDir: '/projects/a',
+			configPath: '/projects/a/orgloop.yaml',
+			loadedAt: '2026-01-01T00:00:00.000Z',
+		});
+
+		const found = await findModuleByDir('/projects/a');
+		expect(found?.name).toBe('mod-a');
+
+		const notFound = await findModuleByDir('/projects/z');
+		expect(notFound).toBeUndefined();
+	});
+
+	it('finds module by name', async () => {
+		await registerModule({
+			name: 'mod-a',
+			sourceDir: '/projects/a',
+			configPath: '/projects/a/orgloop.yaml',
+			loadedAt: '2026-01-01T00:00:00.000Z',
+		});
+
+		const found = await findModuleByName('mod-a');
+		expect(found?.sourceDir).toBe('/projects/a');
+
+		const notFound = await findModuleByName('ghost');
+		expect(notFound).toBeUndefined();
+	});
+
+	it('clears all modules', async () => {
+		await registerModule({
+			name: 'mod-a',
+			sourceDir: '/projects/a',
+			configPath: '/projects/a/orgloop.yaml',
+			loadedAt: '2026-01-01T00:00:00.000Z',
+		});
+		await registerModule({
+			name: 'mod-b',
+			sourceDir: '/projects/b',
+			configPath: '/projects/b/orgloop.yaml',
+			loadedAt: '2026-01-01T00:00:00.000Z',
+		});
+
+		await clearModulesState();
+
+		const state = await readModulesState();
+		expect(state.modules).toHaveLength(0);
+	});
+
+	it('derives module name from config name', () => {
+		expect(deriveModuleName('my-project')).toBe('my-project');
+	});
+
+	it('derives module name from directory when no config name', () => {
+		expect(deriveModuleName(undefined, '/path/to/my-project')).toBe('my-project');
+	});
+});

--- a/packages/cli/src/commands/shutdown.ts
+++ b/packages/cli/src/commands/shutdown.ts
@@ -1,0 +1,121 @@
+/**
+ * orgloop shutdown — Unconditionally stop the daemon and all modules.
+ *
+ * Unlike `orgloop stop` which only removes the current directory's module,
+ * `shutdown` tears down the entire daemon regardless of how many modules
+ * are registered.
+ */
+
+import { readFile, unlink } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { Command } from 'commander';
+import { getDaemonInfo, isProcessRunning, shutdownDaemon } from '../daemon-client.js';
+import { clearModulesState } from '../module-registry.js';
+import * as output from '../output.js';
+
+const PID_DIR = join(homedir(), '.orgloop');
+const PID_FILE = join(PID_DIR, 'orgloop.pid');
+const PORT_FILE = join(PID_DIR, 'runtime.port');
+const SHUTDOWN_TIMEOUT_MS = 10_000;
+
+async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		if (!isProcessRunning(pid)) return true;
+		await new Promise((resolve) => setTimeout(resolve, 200));
+	}
+	return false;
+}
+
+async function cleanupFiles(): Promise<void> {
+	for (const file of [PID_FILE, PORT_FILE]) {
+		try {
+			await unlink(file);
+		} catch {
+			/* ignore */
+		}
+	}
+}
+
+export function registerShutdownCommand(program: Command): void {
+	program
+		.command('shutdown')
+		.description('Shut down the daemon and all registered modules')
+		.option('--force', 'Force kill with SIGKILL')
+		.action(async (opts) => {
+			try {
+				const daemonInfo = await getDaemonInfo();
+
+				if (!daemonInfo) {
+					// Check for stale PID file
+					try {
+						await readFile(PID_FILE, 'utf-8');
+						output.info('OrgLoop is not running (stale PID file). Cleaning up.');
+						await cleanupFiles();
+						await clearModulesState();
+					} catch {
+						output.info('OrgLoop is not running.');
+					}
+					return;
+				}
+
+				const { pid, port } = daemonInfo;
+
+				output.info(`Shutting down OrgLoop daemon (PID ${pid}) and all modules...`);
+
+				if (opts.force) {
+					process.kill(pid, 'SIGKILL');
+					output.success('Force killed.');
+					await cleanupFiles();
+					await clearModulesState();
+					if (output.isJsonMode()) {
+						output.json({ shutdown: true, pid, force: true });
+					}
+					return;
+				}
+
+				// Graceful shutdown via control API
+				output.info('Requesting graceful shutdown via control API...');
+				const apiShutdown = await shutdownDaemon(port);
+
+				if (!apiShutdown) {
+					// Fallback to SIGTERM
+					process.kill(pid, 'SIGTERM');
+					output.info('Sent SIGTERM, waiting for shutdown...');
+				}
+
+				const exited = await waitForExit(pid, SHUTDOWN_TIMEOUT_MS);
+				if (exited) {
+					output.success('Daemon shut down.');
+				} else {
+					output.warn(
+						`Process did not exit within ${SHUTDOWN_TIMEOUT_MS / 1000}s. Sending SIGKILL...`,
+					);
+					try {
+						process.kill(pid, 'SIGKILL');
+					} catch {
+						/* already dead */
+					}
+					output.success('Force killed.');
+				}
+
+				await cleanupFiles();
+				await clearModulesState();
+
+				if (output.isJsonMode()) {
+					output.json({ shutdown: true, pid });
+				}
+			} catch (err) {
+				const errObj = err as NodeJS.ErrnoException;
+				if (errObj.code === 'EPERM' || errObj.code === 'EACCES') {
+					output.error(
+						'Permission denied. The daemon may have been started by another user. Try: sudo orgloop shutdown',
+					);
+				} else {
+					output.error(`Shutdown failed: ${err instanceof Error ? err.message : String(err)}`);
+				}
+				process.exitCode = 1;
+			}
+		});
+}

--- a/packages/cli/src/daemon-client.ts
+++ b/packages/cli/src/daemon-client.ts
@@ -1,0 +1,141 @@
+/**
+ * Daemon client — communicates with a running OrgLoop daemon via its control API.
+ *
+ * Reads ~/.orgloop/runtime.port to discover the daemon's HTTP port,
+ * then makes requests to the control API endpoints.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { ModuleStatus, RuntimeStatus } from '@orgloop/sdk';
+
+const PID_DIR = join(homedir(), '.orgloop');
+const PID_FILE = join(PID_DIR, 'orgloop.pid');
+const PORT_FILE = join(PID_DIR, 'runtime.port');
+
+export interface DaemonInfo {
+	pid: number;
+	port: number;
+}
+
+/** Check if a process is running by PID. */
+export function isProcessRunning(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Read daemon PID and port from state files. Returns null if no daemon is running. */
+export async function getDaemonInfo(): Promise<DaemonInfo | null> {
+	try {
+		const pidStr = await readFile(PID_FILE, 'utf-8');
+		const pid = Number.parseInt(pidStr.trim(), 10);
+		if (Number.isNaN(pid) || !isProcessRunning(pid)) return null;
+
+		const portStr = await readFile(PORT_FILE, 'utf-8');
+		const port = Number.parseInt(portStr.trim(), 10);
+		if (Number.isNaN(port)) return null;
+
+		return { pid, port };
+	} catch {
+		return null;
+	}
+}
+
+/** Get full runtime status from a running daemon. */
+export async function getDaemonStatus(port: number): Promise<RuntimeStatus | null> {
+	try {
+		const res = await fetch(`http://127.0.0.1:${port}/control/status`, {
+			signal: AbortSignal.timeout(3_000),
+		});
+		if (res.ok) {
+			return (await res.json()) as RuntimeStatus;
+		}
+	} catch {
+		// Control API not reachable
+	}
+	return null;
+}
+
+/** List modules registered in a running daemon. */
+export async function listDaemonModules(port: number): Promise<ModuleStatus[]> {
+	try {
+		const res = await fetch(`http://127.0.0.1:${port}/control/module/list`, {
+			signal: AbortSignal.timeout(3_000),
+		});
+		if (res.ok) {
+			return (await res.json()) as ModuleStatus[];
+		}
+	} catch {
+		// Control API not reachable
+	}
+	return [];
+}
+
+/** Load a module into a running daemon via control API. */
+export async function loadModuleIntoDaemon(
+	port: number,
+	moduleConfig: Record<string, unknown>,
+): Promise<ModuleStatus> {
+	const res = await fetch(`http://127.0.0.1:${port}/control/module/load`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(moduleConfig),
+		signal: AbortSignal.timeout(10_000),
+	});
+
+	if (!res.ok) {
+		const body = (await res.json().catch(() => ({}))) as { error?: string };
+		throw new Error(body.error ?? `HTTP ${res.status}`);
+	}
+
+	return (await res.json()) as ModuleStatus;
+}
+
+/** Unload a module from a running daemon via control API. */
+export async function unloadModuleFromDaemon(port: number, moduleName: string): Promise<void> {
+	const res = await fetch(`http://127.0.0.1:${port}/control/module/unload`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: moduleName }),
+		signal: AbortSignal.timeout(10_000),
+	});
+
+	if (!res.ok) {
+		const body = (await res.json().catch(() => ({}))) as { error?: string };
+		throw new Error(body.error ?? `HTTP ${res.status}`);
+	}
+}
+
+/** Reload a module in a running daemon via control API. */
+export async function reloadModuleInDaemon(port: number, moduleName: string): Promise<void> {
+	const res = await fetch(`http://127.0.0.1:${port}/control/module/reload`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: moduleName }),
+		signal: AbortSignal.timeout(10_000),
+	});
+
+	if (!res.ok) {
+		const body = (await res.json().catch(() => ({}))) as { error?: string };
+		throw new Error(body.error ?? `HTTP ${res.status}`);
+	}
+}
+
+/** Shut down the entire daemon via control API. */
+export async function shutdownDaemon(port: number): Promise<boolean> {
+	try {
+		const res = await fetch(`http://127.0.0.1:${port}/control/shutdown`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			signal: AbortSignal.timeout(5_000),
+		});
+		return res.ok;
+	} catch {
+		return false;
+	}
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,7 @@ import { registerLogsCommand } from './commands/logs.js';
 import { registerPlanCommand } from './commands/plan.js';
 import { registerRoutesCommand } from './commands/routes.js';
 import { registerServiceCommand } from './commands/service.js';
+import { registerShutdownCommand } from './commands/shutdown.js';
 import { registerStartCommand } from './commands/start.js';
 import { registerStatusCommand } from './commands/status.js';
 import { registerStopCommand } from './commands/stop.js';
@@ -74,6 +75,7 @@ async function main(): Promise<void> {
 	registerPlanCommand(program);
 	registerStartCommand(program);
 	registerStopCommand(program);
+	registerShutdownCommand(program);
 	registerStatusCommand(program);
 	registerLogsCommand(program);
 	registerTestCommand(program);

--- a/packages/cli/src/module-registry.ts
+++ b/packages/cli/src/module-registry.ts
@@ -1,0 +1,92 @@
+/**
+ * Module registry — tracks which modules are loaded in the running daemon.
+ *
+ * Persists to ~/.orgloop/modules.json so the CLI can map directories
+ * to module names across commands (start, stop, status).
+ */
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
+
+function stateDir(): string {
+	return join(homedir(), '.orgloop');
+}
+
+function modulesFile(): string {
+	return join(stateDir(), 'modules.json');
+}
+
+export interface RegisteredModule {
+	/** Module name (matches the name in runtime's ModuleRegistry) */
+	name: string;
+	/** Absolute path to the module's source directory */
+	sourceDir: string;
+	/** Absolute path to the config file used */
+	configPath: string;
+	/** ISO timestamp when the module was loaded */
+	loadedAt: string;
+}
+
+export interface ModulesState {
+	modules: RegisteredModule[];
+}
+
+/** Read the current modules state from disk. */
+export async function readModulesState(): Promise<ModulesState> {
+	try {
+		const content = await readFile(modulesFile(), 'utf-8');
+		return JSON.parse(content) as ModulesState;
+	} catch {
+		return { modules: [] };
+	}
+}
+
+/** Write the modules state to disk. */
+export async function writeModulesState(state: ModulesState): Promise<void> {
+	await mkdir(stateDir(), { recursive: true });
+	await writeFile(modulesFile(), JSON.stringify(state, null, 2), 'utf-8');
+}
+
+/** Register a module in the persistent state. Replaces if same name exists. */
+export async function registerModule(entry: RegisteredModule): Promise<void> {
+	const state = await readModulesState();
+	// Remove existing entry with same name or same sourceDir
+	state.modules = state.modules.filter(
+		(m) => m.name !== entry.name && m.sourceDir !== entry.sourceDir,
+	);
+	state.modules.push(entry);
+	await writeModulesState(state);
+}
+
+/** Unregister a module by name. */
+export async function unregisterModule(name: string): Promise<void> {
+	const state = await readModulesState();
+	state.modules = state.modules.filter((m) => m.name !== name);
+	await writeModulesState(state);
+}
+
+/** Find a module by source directory. */
+export async function findModuleByDir(sourceDir: string): Promise<RegisteredModule | undefined> {
+	const state = await readModulesState();
+	const absDir = resolve(sourceDir);
+	return state.modules.find((m) => m.sourceDir === absDir);
+}
+
+/** Find a module by name. */
+export async function findModuleByName(name: string): Promise<RegisteredModule | undefined> {
+	const state = await readModulesState();
+	return state.modules.find((m) => m.name === name);
+}
+
+/** Clear all registered modules (used on full daemon shutdown). */
+export async function clearModulesState(): Promise<void> {
+	await writeModulesState({ modules: [] });
+}
+
+/** Derive a module name from a config or directory. */
+export function deriveModuleName(configName?: string, configDir?: string): string {
+	if (configName) return configName;
+	if (configDir) return basename(configDir);
+	return basename(process.cwd());
+}

--- a/packages/core/src/__tests__/multi-module-runtime.test.ts
+++ b/packages/core/src/__tests__/multi-module-runtime.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Multi-module runtime integration tests.
+ *
+ * Tests the full lifecycle of multiple modules in a single daemon:
+ * - Start daemon with one module
+ * - Register a second module via control API
+ * - Verify both modules are active
+ * - Unload one module, verify the other survives
+ * - Reload a module
+ * - Shut down the daemon
+ */
+
+import { createTestEvent, MockActor, MockSource } from '@orgloop/sdk';
+import { afterEach, describe, expect, it } from 'vitest';
+import { InMemoryBus } from '../bus.js';
+import type { ModuleConfig } from '../module-instance.js';
+import { Runtime } from '../runtime.js';
+
+function makeModuleConfig(name: string, overrides?: Partial<ModuleConfig>): ModuleConfig {
+	return {
+		name,
+		sources: [
+			{
+				id: `${name}-source`,
+				connector: 'mock',
+				config: {},
+				poll: { interval: '5m' },
+			},
+		],
+		actors: [{ id: `${name}-actor`, connector: 'mock', config: {} }],
+		routes: [
+			{
+				name: `${name}-route`,
+				when: { source: `${name}-source`, events: ['resource.changed'] },
+				then: { actor: `${name}-actor` },
+			},
+		],
+		transforms: [],
+		loggers: [],
+		...overrides,
+	};
+}
+
+describe('Multi-module runtime', () => {
+	let runtime: Runtime;
+
+	afterEach(async () => {
+		if (runtime) {
+			try {
+				await runtime.stop();
+			} catch {
+				// already stopped
+			}
+		}
+	});
+
+	it('registers second module while first is running', async () => {
+		runtime = new Runtime({ bus: new InMemoryBus() });
+		await runtime.start();
+
+		// Load first module
+		const sourceA = new MockSource('mod-a-source');
+		const actorA = new MockActor('mod-a-actor');
+		await runtime.loadModule(makeModuleConfig('mod-a'), {
+			sources: new Map([['mod-a-source', sourceA]]),
+			actors: new Map([['mod-a-actor', actorA]]),
+		});
+
+		expect(runtime.listModules()).toHaveLength(1);
+
+		// Load second module
+		const sourceB = new MockSource('mod-b-source');
+		const actorB = new MockActor('mod-b-actor');
+		await runtime.loadModule(makeModuleConfig('mod-b'), {
+			sources: new Map([['mod-b-source', sourceB]]),
+			actors: new Map([['mod-b-actor', actorB]]),
+		});
+
+		expect(runtime.listModules()).toHaveLength(2);
+
+		// Both modules are active
+		const statuses = runtime.listModules();
+		expect(statuses[0]).toMatchObject({ name: 'mod-a', state: 'active' });
+		expect(statuses[1]).toMatchObject({ name: 'mod-b', state: 'active' });
+	});
+
+	it('events route correctly to each module independently', async () => {
+		runtime = new Runtime({ bus: new InMemoryBus() });
+		await runtime.start();
+
+		const actorA = new MockActor('mod-a-actor');
+		const actorB = new MockActor('mod-b-actor');
+
+		await runtime.loadModule(makeModuleConfig('mod-a'), {
+			sources: new Map([['mod-a-source', new MockSource('mod-a-source')]]),
+			actors: new Map([['mod-a-actor', actorA]]),
+		});
+
+		await runtime.loadModule(makeModuleConfig('mod-b'), {
+			sources: new Map([['mod-b-source', new MockSource('mod-b-source')]]),
+			actors: new Map([['mod-b-actor', actorB]]),
+		});
+
+		// Event to mod-a
+		await runtime.inject(
+			createTestEvent({ source: 'mod-a-source', type: 'resource.changed' }),
+			'mod-a',
+		);
+
+		// Event to mod-b
+		await runtime.inject(
+			createTestEvent({ source: 'mod-b-source', type: 'resource.changed' }),
+			'mod-b',
+		);
+
+		expect(actorA.delivered).toHaveLength(1);
+		expect(actorB.delivered).toHaveLength(1);
+		expect(actorA.delivered[0].event.source).toBe('mod-a-source');
+		expect(actorB.delivered[0].event.source).toBe('mod-b-source');
+	});
+
+	it('unloading one module does not affect others', async () => {
+		runtime = new Runtime({ bus: new InMemoryBus() });
+		await runtime.start();
+
+		const sourceA = new MockSource('mod-a-source');
+		const actorA = new MockActor('mod-a-actor');
+		const sourceB = new MockSource('mod-b-source');
+		const actorB = new MockActor('mod-b-actor');
+
+		await runtime.loadModule(makeModuleConfig('mod-a'), {
+			sources: new Map([['mod-a-source', sourceA]]),
+			actors: new Map([['mod-a-actor', actorA]]),
+		});
+
+		await runtime.loadModule(makeModuleConfig('mod-b'), {
+			sources: new Map([['mod-b-source', sourceB]]),
+			actors: new Map([['mod-b-actor', actorB]]),
+		});
+
+		// Unload mod-a
+		await runtime.unloadModule('mod-a');
+
+		expect(runtime.listModules()).toHaveLength(1);
+		expect(runtime.listModules()[0]).toMatchObject({ name: 'mod-b', state: 'active' });
+		expect(sourceA.shutdownCalled).toBe(true);
+
+		// mod-b still works
+		await runtime.inject(
+			createTestEvent({ source: 'mod-b-source', type: 'resource.changed' }),
+			'mod-b',
+		);
+		expect(actorB.delivered).toHaveLength(1);
+	});
+
+	it('supports hot-reload: unload then load same name', async () => {
+		runtime = new Runtime({ bus: new InMemoryBus() });
+		await runtime.start();
+
+		const sourceA1 = new MockSource('mod-a-source');
+		const actorA1 = new MockActor('mod-a-actor');
+
+		await runtime.loadModule(makeModuleConfig('mod-a'), {
+			sources: new Map([['mod-a-source', sourceA1]]),
+			actors: new Map([['mod-a-actor', actorA1]]),
+		});
+
+		// Unload and reload with new instances
+		await runtime.unloadModule('mod-a');
+		expect(sourceA1.shutdownCalled).toBe(true);
+
+		const sourceA2 = new MockSource('mod-a-source');
+		const actorA2 = new MockActor('mod-a-actor');
+
+		await runtime.loadModule(makeModuleConfig('mod-a'), {
+			sources: new Map([['mod-a-source', sourceA2]]),
+			actors: new Map([['mod-a-actor', actorA2]]),
+		});
+
+		// New instance works
+		await runtime.inject(
+			createTestEvent({ source: 'mod-a-source', type: 'resource.changed' }),
+			'mod-a',
+		);
+		expect(actorA2.delivered).toHaveLength(1);
+		expect(actorA1.delivered).toHaveLength(0);
+	});
+
+	it('runtime.status() shows all modules', async () => {
+		runtime = new Runtime({ bus: new InMemoryBus() });
+		await runtime.start();
+
+		await runtime.loadModule(makeModuleConfig('mod-a'), {
+			sources: new Map([['mod-a-source', new MockSource('mod-a-source')]]),
+			actors: new Map([['mod-a-actor', new MockActor('mod-a-actor')]]),
+		});
+
+		await runtime.loadModule(makeModuleConfig('mod-b'), {
+			sources: new Map([['mod-b-source', new MockSource('mod-b-source')]]),
+			actors: new Map([['mod-b-actor', new MockActor('mod-b-actor')]]),
+		});
+
+		const status = runtime.status();
+		expect(status.running).toBe(true);
+		expect(status.modules).toHaveLength(2);
+		expect(status.modules.map((m) => m.name).sort()).toEqual(['mod-a', 'mod-b']);
+	});
+
+	it('getModuleStatus() returns individual module status', async () => {
+		runtime = new Runtime({ bus: new InMemoryBus() });
+		await runtime.start();
+
+		await runtime.loadModule(makeModuleConfig('mod-a'), {
+			sources: new Map([['mod-a-source', new MockSource('mod-a-source')]]),
+			actors: new Map([['mod-a-actor', new MockActor('mod-a-actor')]]),
+		});
+
+		const modStatus = runtime.getModuleStatus('mod-a');
+		expect(modStatus).toBeDefined();
+		expect(modStatus?.name).toBe('mod-a');
+		expect(modStatus?.state).toBe('active');
+
+		const missing = runtime.getModuleStatus('ghost');
+		expect(missing).toBeUndefined();
+	});
+
+	it('custom control handler is invoked', async () => {
+		const port = 10000 + Math.floor(Math.random() * 50000);
+		runtime = new Runtime({ bus: new InMemoryBus(), httpPort: port });
+		await runtime.start();
+		await runtime.startHttpServer();
+
+		let handlerCalled = false;
+
+		runtime.registerControlHandler('test/echo', async (body) => {
+			handlerCalled = true;
+			return { echo: true, received: body };
+		});
+
+		const res = await fetch(`http://127.0.0.1:${port}/control/test/echo`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ hello: 'world' }),
+		});
+
+		expect(res.ok).toBe(true);
+		const json = (await res.json()) as { echo: boolean; received: { hello: string } };
+		expect(json.echo).toBe(true);
+		expect(json.received.hello).toBe('world');
+		expect(handlerCalled).toBe(true);
+	});
+
+	it('survives after removing all modules (runtime stays up)', async () => {
+		runtime = new Runtime({ bus: new InMemoryBus() });
+		await runtime.start();
+
+		await runtime.loadModule(makeModuleConfig('mod-a'), {
+			sources: new Map([['mod-a-source', new MockSource('mod-a-source')]]),
+			actors: new Map([['mod-a-actor', new MockActor('mod-a-actor')]]),
+		});
+
+		await runtime.unloadModule('mod-a');
+
+		// Runtime is still running
+		expect(runtime.status().running).toBe(true);
+		expect(runtime.listModules()).toHaveLength(0);
+
+		// Can add a new module after clearing
+		await runtime.loadModule(makeModuleConfig('mod-b'), {
+			sources: new Map([['mod-b-source', new MockSource('mod-b-source')]]),
+			actors: new Map([['mod-b-actor', new MockActor('mod-b-actor')]]),
+		});
+
+		expect(runtime.listModules()).toHaveLength(1);
+	});
+
+	it('full lifecycle: start → add → add → remove → survive → shutdown', async () => {
+		runtime = new Runtime({ bus: new InMemoryBus() });
+		await runtime.start();
+		expect(runtime.status().running).toBe(true);
+
+		// Add mod-a
+		const actorA = new MockActor('mod-a-actor');
+		await runtime.loadModule(makeModuleConfig('mod-a'), {
+			sources: new Map([['mod-a-source', new MockSource('mod-a-source')]]),
+			actors: new Map([['mod-a-actor', actorA]]),
+		});
+		expect(runtime.listModules()).toHaveLength(1);
+
+		// Add mod-b
+		const actorB = new MockActor('mod-b-actor');
+		await runtime.loadModule(makeModuleConfig('mod-b'), {
+			sources: new Map([['mod-b-source', new MockSource('mod-b-source')]]),
+			actors: new Map([['mod-b-actor', actorB]]),
+		});
+		expect(runtime.listModules()).toHaveLength(2);
+
+		// Remove mod-a
+		await runtime.unloadModule('mod-a');
+		expect(runtime.listModules()).toHaveLength(1);
+
+		// mod-b survives
+		await runtime.inject(
+			createTestEvent({ source: 'mod-b-source', type: 'resource.changed' }),
+			'mod-b',
+		);
+		expect(actorB.delivered).toHaveLength(1);
+
+		// Shutdown
+		await runtime.stop();
+		expect(runtime.status().running).toBe(false);
+	});
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -799,6 +799,16 @@ class Runtime extends EventEmitter implements RuntimeControl {
 		}
 	}
 
+	// ─── Custom Control Handlers ─────────────────────────────────────────────
+
+	/** Register a custom control API handler for a given route suffix. */
+	registerControlHandler(
+		route: string,
+		handler: (body: Record<string, unknown>) => Promise<unknown>,
+	): void {
+		this.webhookServer.registerControlHandler(route, handler);
+	}
+
 	// ─── RuntimeControl Implementation ───────────────────────────────────────
 
 	status(): RuntimeStatus {


### PR DESCRIPTION
Closes #44.

## Summary

Makes the CLI module-aware so multiple OrgLoop projects can share a single daemon process, with independent lifecycles and no restarts.

- **`orgloop start`**: Detects a running daemon and registers the current directory's module via the control API. Supports idempotent hot-reload if the same module is already loaded.
- **`orgloop stop`**: Unloads only the current directory's module. Shuts down the daemon if it's the last module. `--all` flag for full daemon stop.
- **`orgloop shutdown`**: New command — unconditionally stops the daemon and all modules.
- **`orgloop status`**: Shows all loaded modules with directories, state, source/route counts.
- **Module state tracking**: `~/.orgloop/modules.json` tracks module name, source directory, config path, and load time across CLI commands.
- **Custom control handlers**: New mechanism on `Runtime`/`WebhookServer` for extensible control API endpoints (used by `module/load-project`).

## New files

- `packages/cli/src/daemon-client.ts` — HTTP client for communicating with running daemon
- `packages/cli/src/module-registry.ts` — Persistent module tracking (`~/.orgloop/modules.json`)
- `packages/cli/src/commands/shutdown.ts` — Unconditional daemon shutdown command
- `packages/core/src/__tests__/multi-module-runtime.test.ts` — 9 integration tests
- `packages/cli/src/__tests__/module-registry.test.ts` — 12 unit tests

## Test plan

- [x] 9 multi-module runtime integration tests (load, unload, reload, event routing, control handlers, full lifecycle)
- [x] 12 module registry unit tests (CRUD, find by dir/name, clear, derive name)
- [x] `pnpm build` — 21 packages pass
- [x] `pnpm test` — 42 suites, all pass (223 CLI + 151 core)
- [x] `pnpm typecheck` — 40 packages clean
- [x] `pnpm lint` — no new warnings

## Documentation updated

- AGENTS.md (key classes table, test coverage table)
- README.md (multi-module daemon bullet point)
- `docs-site/src/content/docs/spec/cli-design.md` (start, stop, shutdown, status)
- `docs-site/src/content/docs/spec/runtime-lifecycle.md` (multi-module architecture, project loading, state management)
- `docs-site/src/content/docs/spec/modules.md` (multi-project runtimes section, runtime loading flow)

🤖 AI-assisted. All code reviewed by author.