### PR TITLE
release: @orgloop/cli v0.2.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/cli",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "description": "OrgLoop command-line interface",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Multi-module single daemon runtime, per-route channel/to overrides. 1046 tests passing.