### PR TITLE
fix: resolve lint warnings (unused imports/params)

### DIFF
--- a/connectors/agent-ctl/src/source.ts
+++ b/connectors/agent-ctl/src/source.ts
@@ -94,7 +94,7 @@ export class AgentCtlSource implements SourceConnector {
 		this.execFn = fn;
 	}
 
-	async poll(checkpoint: string | null): Promise<PollResult> {
+	async poll(_checkpoint: string | null): Promise<PollResult> {
 		const sessions = await this.listSessions();
 		const currentState = new Map(sessions.map((s) => [s.id, s]));
 		const events = this.diffState(currentState);

--- a/connectors/docker/src/__tests__/target.test.ts
+++ b/connectors/docker/src/__tests__/target.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ExecFn } from '../target.js';
 import { DockerTarget } from '../target.js';
 
-function successExec(): ExecFn {
+function _successExec(): ExecFn {
 	return vi.fn(async () => ({ stdout: '', stderr: '' }));
 }
 

--- a/transforms/agent-gate/src/__tests__/agent-gate.test.ts
+++ b/transforms/agent-gate/src/__tests__/agent-gate.test.ts
@@ -1,6 +1,5 @@
 import { createTestContext, createTestEvent } from '@orgloop/sdk';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import type { AgentGateConfig } from '../agent-gate.js';
 import { AgentGateTransform } from '../agent-gate.js';
 
 function mockExecFn(sessions: Array<{ status: string; adapter: string }>) {


### PR DESCRIPTION
Fixes 3 lint warnings flagged in https://github.com/OrgLoop/orgloop/pull/50#issuecomment-3953883593:

- `connectors/agent-ctl/src/source.ts`: prefix unused `checkpoint` param with underscore
- `connectors/docker/src/__tests__/target.test.ts`: prefix unused `successExec` with underscore
- `transforms/agent-gate/src/__tests__/agent-gate.test.ts`: remove unused `AgentGateConfig` import

The 4th issue (GitHub source test formatting) appears already resolved on main.