### PR TITLE
release: v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,6 @@
   },
   "dependencies": {
     "@orgloop/transform-agent-gate": "workspace:^"
-  }
+  },
+  "version": "0.3.0"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "OrgLoop command-line interface",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/core",
-  "version": "0.1.10",
+  "version": "0.3.0",
   "description": "OrgLoop runtime engine — library-first event routing",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/sdk",
-  "version": "0.1.9",
+  "version": "0.3.0",
   "description": "OrgLoop plugin development kit — interfaces, base classes, and test harnesses",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/server",
-  "version": "0.1.9",
+  "version": "0.3.0",
   "description": "OrgLoop HTTP API server",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes since v0.2.0

- fix(github): token rotation, per-endpoint error isolation, resource_id for dedup (#50)
- feat(connector-openclaw): interpolate event fields in session_key (#51)
- fix: resolve lint warnings (#52)
- deps: bumped biome + inquirer

All 1050 tests pass.