### PR TITLE
feat(github,linear): batch GraphQL polling replaces N+1 REST/SDK patterns

### DIFF
--- a/connectors/github/src/graphql.ts
+++ b/connectors/github/src/graphql.ts
@@ -1,0 +1,272 @@
+/**
+ * Batched GraphQL queries for the GitHub connector.
+ *
+ * Replaces the N+1 REST pattern (one pulls.listReviews call per PR) with a
+ * single GraphQL query that fetches PRs with reviews inline. Also combines
+ * the separate PR-state queries (closed, opened, ready-for-review) into the
+ * same batch.
+ *
+ * The response is mapped to REST-compatible shapes so the existing normalizers
+ * work unchanged.
+ */
+
+import type { Octokit } from '@octokit/rest';
+
+// ─── GraphQL Response Types ─────────────────────────────────────────────────
+
+interface GqlAuthor {
+	login: string;
+	__typename: string;
+}
+
+interface GqlReviewNode {
+	databaseId: number;
+	state: string;
+	body: string | null;
+	submittedAt: string | null;
+	url: string;
+	author: GqlAuthor | null;
+}
+
+interface GqlPullRequestNode {
+	databaseId: number;
+	number: number;
+	title: string;
+	updatedAt: string;
+	closedAt: string | null;
+	createdAt: string;
+	merged: boolean;
+	isDraft: boolean;
+	state: 'OPEN' | 'CLOSED' | 'MERGED';
+	url: string;
+	headRefName: string;
+	baseRefName: string;
+	author: GqlAuthor | null;
+	mergedBy: GqlAuthor | null;
+	reviews: {
+		nodes: GqlReviewNode[];
+	};
+}
+
+interface GqlPageInfo {
+	hasNextPage: boolean;
+	endCursor: string | null;
+}
+
+interface GqlBatchResponse {
+	repository: {
+		pullRequests: {
+			nodes: GqlPullRequestNode[];
+			pageInfo: GqlPageInfo;
+		};
+	};
+	rateLimit: {
+		remaining: number;
+		resetAt: string;
+	};
+}
+
+// ─── REST-Compatible Types ──────────────────────────────────────────────────
+
+export type RestPull = Record<string, unknown>;
+export type RestReview = Record<string, unknown>;
+
+/** Result of the batch GraphQL query, mapped to REST-compatible shapes */
+export interface BatchPRResult {
+	/** All recently-updated PRs (REST format), for sharing with other poll methods */
+	pulls: RestPull[];
+	/** PR review events, already filtered by `since` */
+	reviews: Array<{ review: RestReview; pr: RestPull }>;
+	/** PRs closed/merged after `since` */
+	closedPRs: RestPull[];
+	/** PRs opened after `since` */
+	openedPRs: RestPull[];
+	/** Non-draft PRs updated after `since` (ready for review) */
+	readyForReviewPRs: RestPull[];
+	/** Rate limit state from the GraphQL response */
+	rateLimit: { remaining: number; resetAt: Date };
+}
+
+// ─── Query ──────────────────────────────────────────────────────────────────
+
+const BATCH_PR_QUERY = `
+  query BatchPollPRs($owner: String!, $name: String!, $first: Int!, $after: String) {
+    repository(owner: $owner, name: $name) {
+      pullRequests(
+        first: $first
+        after: $after
+        orderBy: { field: UPDATED_AT, direction: DESC }
+      ) {
+        nodes {
+          databaseId
+          number
+          title
+          updatedAt
+          closedAt
+          createdAt
+          merged
+          isDraft
+          state
+          url
+          headRefName
+          baseRefName
+          author { login __typename }
+          mergedBy { login }
+          reviews(last: 100) {
+            nodes {
+              databaseId
+              state
+              body
+              submittedAt
+              url
+              author { login __typename }
+            }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+    rateLimit { remaining resetAt }
+  }
+`;
+
+// ─── GraphQL → REST Mapping ─────────────────────────────────────────────────
+
+/** Map a GraphQL Author to REST user shape */
+function mapAuthor(author: GqlAuthor | null): Record<string, unknown> | undefined {
+	if (!author) return undefined;
+	return {
+		login: author.login,
+		type: author.__typename === 'Bot' ? 'Bot' : 'User',
+	};
+}
+
+/** Map a GraphQL PR node to the REST PR shape expected by normalizers */
+function mapPullToRest(pr: GqlPullRequestNode): RestPull {
+	return {
+		number: pr.number,
+		title: pr.title,
+		updated_at: pr.updatedAt,
+		closed_at: pr.closedAt,
+		created_at: pr.createdAt,
+		merged: pr.merged,
+		draft: pr.isDraft,
+		state: pr.state.toLowerCase(),
+		html_url: pr.url,
+		user: mapAuthor(pr.author),
+		merged_by: pr.mergedBy ? { login: pr.mergedBy.login } : undefined,
+		head: { ref: pr.headRefName },
+		base: { ref: pr.baseRefName },
+	};
+}
+
+/** Map a GraphQL review node to the REST review shape expected by normalizers */
+function mapReviewToRest(review: GqlReviewNode): RestReview {
+	return {
+		id: review.databaseId,
+		state: review.state,
+		body: review.body,
+		submitted_at: review.submittedAt,
+		html_url: review.url,
+		user: mapAuthor(review.author),
+	};
+}
+
+// ─── Execution ──────────────────────────────────────────────────────────────
+
+export interface BatchQueryOptions {
+	octokit: Octokit;
+	owner: string;
+	repo: string;
+	since: string;
+	pageSize?: number;
+}
+
+/**
+ * Execute the batch GraphQL query. Paginates through all recently-updated PRs,
+ * stopping when all PRs on a page are older than `since` (early termination).
+ *
+ * Returns PRs with reviews in REST-compatible format, plus categorized PR
+ * events (closed, opened, ready-for-review).
+ */
+export async function executeBatchPRQuery(opts: BatchQueryOptions): Promise<BatchPRResult> {
+	const { octokit, owner, repo, since } = opts;
+	const pageSize = opts.pageSize ?? 50;
+
+	const allPulls: RestPull[] = [];
+	const allReviews: Array<{ review: RestReview; pr: RestPull }> = [];
+	const closedPRs: RestPull[] = [];
+	const openedPRs: RestPull[] = [];
+	const readyForReviewPRs: RestPull[] = [];
+	let lastRateLimit = { remaining: 5000, resetAt: new Date() };
+
+	let hasNextPage = true;
+	let cursor: string | undefined;
+
+	while (hasNextPage) {
+		const variables: Record<string, unknown> = {
+			owner,
+			name: repo,
+			first: pageSize,
+		};
+		if (cursor) {
+			variables.after = cursor;
+		}
+
+		const data = await octokit.graphql<GqlBatchResponse>(BATCH_PR_QUERY, variables);
+
+		// Update rate limit from response
+		lastRateLimit = {
+			remaining: data.rateLimit.remaining,
+			resetAt: new Date(data.rateLimit.resetAt),
+		};
+
+		const { nodes, pageInfo } = data.repository.pullRequests;
+		let allOlderThanSince = true;
+
+		for (const gqlPR of nodes) {
+			if (gqlPR.updatedAt >= since) {
+				allOlderThanSince = false;
+				const restPR = mapPullToRest(gqlPR);
+				allPulls.push(restPR);
+
+				// Extract reviews newer than `since`
+				for (const gqlReview of gqlPR.reviews.nodes) {
+					if (gqlReview.submittedAt && gqlReview.submittedAt > since) {
+						allReviews.push({
+							review: mapReviewToRest(gqlReview),
+							pr: restPR,
+						});
+					}
+				}
+
+				// Categorize PR events
+				if (gqlPR.closedAt && gqlPR.closedAt > since) {
+					closedPRs.push(restPR);
+				}
+				if (gqlPR.createdAt > since && gqlPR.state === 'OPEN') {
+					openedPRs.push(restPR);
+				}
+				if (!gqlPR.isDraft && gqlPR.updatedAt > since && gqlPR.state === 'OPEN') {
+					readyForReviewPRs.push(restPR);
+				}
+			}
+		}
+
+		// Early termination: if all PRs on this page are older than since, stop
+		if ((allOlderThanSince && nodes.length > 0) || !pageInfo.hasNextPage) {
+			hasNextPage = false;
+		} else {
+			cursor = pageInfo.endCursor ?? undefined;
+		}
+	}
+
+	return {
+		pulls: allPulls,
+		reviews: allReviews,
+		closedPRs,
+		openedPRs,
+		readyForReviewPRs,
+		rateLimit: lastRateLimit,
+	};
+}

--- a/connectors/github/src/source.ts
+++ b/connectors/github/src/source.ts
@@ -1,15 +1,14 @@
 /**
  * GitHub source connector — polls GitHub API for repository events.
  *
- * Smart polling strategy (WQ-94):
- * - Repo-level endpoints for review comments (replaces per-PR scraping)
- * - Local PR state cache (skip unchanged PRs for reviews)
- * - Rate budget awareness (skip non-essential events when budget low)
+ * Uses a batched GraphQL query for PR-related events (reviews, closed,
+ * opened, ready-for-review) to eliminate the N+1 pattern of per-PR REST
+ * calls. Remaining endpoints (review comments, issue comments, workflow
+ * runs, check suites) use efficient single-call REST endpoints.
  *
- * Rate limit awareness: reads X-RateLimit-Remaining/Reset headers,
- * warns when low, pauses when exhausted. Initial sync defaults to a
- * configurable lookback window (default 7d) instead of epoch to avoid
- * burning through the 5000 req/hr limit on large repos.
+ * Rate limit awareness: reads X-RateLimit-Remaining/Reset headers for REST,
+ * rateLimit query field for GraphQL. Warns when low, pauses when exhausted.
+ * Initial sync defaults to a configurable lookback window (default 7d).
  */
 
 import { Octokit } from '@octokit/rest';
@@ -26,6 +25,7 @@ import {
 	createHttpAgent,
 	parseDuration,
 } from '@orgloop/sdk';
+import { executeBatchPRQuery } from './graphql.js';
 import {
 	normalizeCheckSuiteCompleted,
 	normalizeIssueComment,
@@ -189,71 +189,91 @@ export class GitHubSource implements SourceConnector {
 			// Check rate limit before starting
 			await this.checkRateLimit();
 
-			// Fetch PRs once for methods that need them (reviews + review comments)
-			const needsPulls =
+			// ─── Batch GraphQL: PRs + Reviews ───────────────────────────
+			// Single GraphQL query replaces: fetchUpdatedPulls + pollReviews
+			// + pollClosedPRs + pollOpenedPRs + pollReadyForReviewPRs
+
+			const needsPRBatch =
 				this.events.includes('pull_request.review_submitted') ||
-				this.events.includes('pull_request_review_comment');
+				this.events.includes('pull_request_review_comment') ||
+				this.events.includes('pull_request.closed') ||
+				this.events.includes('pull_request.merged') ||
+				this.events.includes('pull_request.opened') ||
+				this.events.includes('pull_request.ready_for_review');
 
 			let pulls: GitHubPull[] = [];
-			if (needsPulls) {
-				pulls = await this.fetchUpdatedPulls(since);
+
+			if (needsPRBatch) {
+				const batchResult = await executeBatchPRQuery({
+					octokit: this.octokit,
+					owner: this.owner,
+					repo: this.repo,
+					since,
+				});
+				this.pollBudget.apiCalls++;
+
+				// Update rate limit from GraphQL response
+				this.rateLimit = batchResult.rateLimit;
+
+				pulls = batchResult.pulls;
+				const repoData = { full_name: `${this.owner}/${this.repo}` };
+
+				// PR reviews
+				if (this.events.includes('pull_request.review_submitted')) {
+					// Filter by PR cache: skip reviews on PRs whose updated_at didn't change
+					for (const { review, pr } of batchResult.reviews) {
+						const prNumber = pr.number as number;
+						const prUpdatedAt = pr.updated_at as string;
+						const cachedUpdatedAt = this.prCache.get(prNumber);
+						if (cachedUpdatedAt && cachedUpdatedAt === prUpdatedAt) {
+							continue;
+						}
+						events.push(normalizePullRequestReview(this.sourceId, review, pr, repoData));
+					}
+					// Update PR cache
+					for (const pr of pulls) {
+						this.prCache.set(pr.number as number, pr.updated_at as string);
+					}
+				}
+
+				// Closed/merged PRs
+				if (
+					this.events.includes('pull_request.closed') ||
+					this.events.includes('pull_request.merged')
+				) {
+					for (const pr of batchResult.closedPRs) {
+						events.push(normalizePullRequestClosed(this.sourceId, pr, repoData));
+					}
+				}
+
+				// Opened PRs
+				if (this.events.includes('pull_request.opened')) {
+					for (const pr of batchResult.openedPRs) {
+						events.push(normalizePullRequestOpened(this.sourceId, pr, repoData));
+					}
+				}
+
+				// Ready for review PRs
+				if (this.events.includes('pull_request.ready_for_review')) {
+					for (const pr of batchResult.readyForReviewPRs) {
+						events.push(normalizePullRequestReadyForReview(this.sourceId, pr, repoData));
+					}
+				}
 			}
 
-			if (this.events.includes('pull_request.review_submitted')) {
-				const reviews = await this.pollReviews(since, pulls);
-				events.push(...reviews);
-			}
-
-			// WQ-94: Use repo-level endpoint for review comments instead of per-PR
+			// ─── REST: Review comments (repo-level, single call) ────────
 			if (this.events.includes('pull_request_review_comment')) {
 				const comments = await this.pollReviewCommentsRepoLevel(since, pulls);
 				events.push(...comments);
 			}
 
+			// ─── REST: Issue comments (single call) ─────────────────────
 			if (this.events.includes('issue_comment')) {
 				const comments = await this.pollIssueComments(since);
 				events.push(...comments);
 			}
 
-			// Non-essential event types: skip if rate budget is low.
-			// Each is wrapped in try/catch so a permissions error on one endpoint
-			// (e.g. 403 on workflow_run without Actions scope) doesn't abort the whole poll.
-			if (
-				this.events.includes('pull_request.closed') ||
-				this.events.includes('pull_request.merged')
-			) {
-				if (this.hasBudget()) {
-					try {
-						const prs = await this.pollClosedPRs(since);
-						events.push(...prs);
-					} catch (e: unknown) {
-						console.warn(`[github] Failed to poll closed PRs: ${(e as Error).message}`);
-					}
-				}
-			}
-
-			if (this.events.includes('pull_request.opened')) {
-				if (this.hasBudget()) {
-					try {
-						const prs = await this.pollOpenedPRs(since);
-						events.push(...prs);
-					} catch (e: unknown) {
-						console.warn(`[github] Failed to poll opened PRs: ${(e as Error).message}`);
-					}
-				}
-			}
-
-			if (this.events.includes('pull_request.ready_for_review')) {
-				if (this.hasBudget()) {
-					try {
-						const prs = await this.pollReadyForReviewPRs(since);
-						events.push(...prs);
-					} catch (e: unknown) {
-						console.warn(`[github] Failed to poll ready-for-review PRs: ${(e as Error).message}`);
-					}
-				}
-			}
-
+			// ─── REST: Non-essential events (skip if budget low) ────────
 			if (this.events.includes('workflow_run.completed')) {
 				if (this.hasBudget()) {
 					try {
@@ -292,7 +312,6 @@ export class GitHubSource implements SourceConnector {
 					? ` Resets at ${this.rateLimit.resetAt.toISOString()}`
 					: '';
 				console.warn(`[github] Rate limited.${resetInfo} Returning partial results.`);
-				// Return what we have so far with current checkpoint
 				this.logBudget();
 				return {
 					events: this.filterByAuthors(events),
@@ -422,105 +441,6 @@ export class GitHubSource implements SourceConnector {
 			}
 		}
 		this.lastCacheEviction = now;
-	}
-
-	/**
-	 * Fetch recently-updated PRs using pagination with early termination.
-	 * Stops fetching pages once PRs are older than the since cutoff.
-	 */
-	private async fetchUpdatedPulls(since: string): Promise<GitHubPull[]> {
-		const result: GitHubPull[] = [];
-
-		// Use manual pagination with early termination to avoid fetching
-		// all PRs in repos with thousands of them
-		const iterator = this.octokit.paginate.iterator(this.octokit.pulls.list, {
-			owner: this.owner,
-			repo: this.repo,
-			state: 'all',
-			sort: 'updated',
-			direction: 'desc',
-			per_page: 100,
-		});
-
-		for await (const response of iterator) {
-			this.pollBudget.apiCalls++;
-			// Track rate limit from each response
-			if (response.headers) {
-				this.updateRateLimitFromHeaders(response.headers as unknown as Record<string, string>);
-			}
-
-			const pulls = response.data as unknown as GitHubPull[];
-			let allOlderThanSince = true;
-
-			for (const pr of pulls) {
-				if (pr.updated_at && (pr.updated_at as string) >= since) {
-					result.push(pr);
-					allOlderThanSince = false;
-				}
-			}
-
-			// If every PR on this page is older than `since`, no need to fetch more
-			if (allOlderThanSince && pulls.length > 0) {
-				break;
-			}
-		}
-
-		return result;
-	}
-
-	/**
-	 * WQ-94: Only fetch reviews for PRs whose updated_at changed since last poll.
-	 * Skips unchanged PRs to reduce API calls.
-	 */
-	private async pollReviews(since: string, pulls: GitHubPull[]): Promise<OrgLoopEvent[]> {
-		const events: OrgLoopEvent[] = [];
-		const repoData = { full_name: `${this.owner}/${this.repo}` };
-
-		for (const pr of pulls) {
-			const prNumber = pr.number as number;
-			const prUpdatedAt = pr.updated_at as string;
-
-			// WQ-94: Skip PRs whose updated_at hasn't changed since last poll
-			const cachedUpdatedAt = this.prCache.get(prNumber);
-			if (cachedUpdatedAt && cachedUpdatedAt === prUpdatedAt) {
-				continue;
-			}
-
-			// Check rate limit before each per-PR API call
-			await this.checkRateLimit();
-			if (!this.hasBudget()) break;
-
-			try {
-				this.pollBudget.apiCalls++;
-				const reviews = await this.octokit.paginate(this.octokit.pulls.listReviews, {
-					owner: this.owner,
-					repo: this.repo,
-					pull_number: prNumber,
-					per_page: 100,
-				});
-				for (const review of reviews) {
-					const submitted = (review as unknown as Record<string, unknown>).submitted_at as
-						| string
-						| undefined;
-					if (submitted && submitted > since) {
-						events.push(
-							normalizePullRequestReview(
-								this.sourceId,
-								review as unknown as Record<string, unknown>,
-								pr,
-								repoData,
-							),
-						);
-					}
-				}
-			} catch {
-				// Skip individual PR errors
-			}
-
-			// Update cache after successful fetch
-			this.prCache.set(prNumber, prUpdatedAt);
-		}
-		return events;
 	}
 
 	/**
@@ -661,123 +581,6 @@ export class GitHubSource implements SourceConnector {
 					repoData,
 				);
 			});
-	}
-
-	private async pollClosedPRs(since: string): Promise<OrgLoopEvent[]> {
-		const events: OrgLoopEvent[] = [];
-		const repoData = { full_name: `${this.owner}/${this.repo}` };
-
-		const iterator = this.octokit.paginate.iterator(this.octokit.pulls.list, {
-			owner: this.owner,
-			repo: this.repo,
-			state: 'closed',
-			sort: 'updated',
-			direction: 'desc',
-			per_page: 100,
-		});
-
-		for await (const response of iterator) {
-			this.pollBudget.apiCalls++;
-			if (response.headers) {
-				this.updateRateLimitFromHeaders(response.headers as unknown as Record<string, string>);
-			}
-
-			const pulls = response.data as unknown as GitHubPull[];
-			let allOlderThanSince = true;
-
-			for (const pr of pulls) {
-				if (pr.updated_at && (pr.updated_at as string) >= since) {
-					allOlderThanSince = false;
-					if (pr.closed_at && (pr.closed_at as string) > since) {
-						events.push(normalizePullRequestClosed(this.sourceId, pr, repoData));
-					}
-				}
-			}
-
-			if (allOlderThanSince && pulls.length > 0) {
-				break;
-			}
-		}
-
-		return events;
-	}
-
-	private async pollOpenedPRs(since: string): Promise<OrgLoopEvent[]> {
-		const events: OrgLoopEvent[] = [];
-		const repoData = { full_name: `${this.owner}/${this.repo}` };
-
-		const iterator = this.octokit.paginate.iterator(this.octokit.pulls.list, {
-			owner: this.owner,
-			repo: this.repo,
-			state: 'open',
-			sort: 'created',
-			direction: 'desc',
-			per_page: 100,
-		});
-
-		for await (const response of iterator) {
-			this.pollBudget.apiCalls++;
-			if (response.headers) {
-				this.updateRateLimitFromHeaders(response.headers as unknown as Record<string, string>);
-			}
-
-			const pulls = response.data as unknown as GitHubPull[];
-			let allOlderThanSince = true;
-
-			for (const pr of pulls) {
-				if (pr.created_at && (pr.created_at as string) >= since) {
-					allOlderThanSince = false;
-					if ((pr.created_at as string) > since) {
-						events.push(normalizePullRequestOpened(this.sourceId, pr, repoData));
-					}
-				}
-			}
-
-			if (allOlderThanSince && pulls.length > 0) {
-				break;
-			}
-		}
-
-		return events;
-	}
-
-	private async pollReadyForReviewPRs(since: string): Promise<OrgLoopEvent[]> {
-		const events: OrgLoopEvent[] = [];
-		const repoData = { full_name: `${this.owner}/${this.repo}` };
-
-		const iterator = this.octokit.paginate.iterator(this.octokit.pulls.list, {
-			owner: this.owner,
-			repo: this.repo,
-			state: 'open',
-			sort: 'updated',
-			direction: 'desc',
-			per_page: 100,
-		});
-
-		for await (const response of iterator) {
-			this.pollBudget.apiCalls++;
-			if (response.headers) {
-				this.updateRateLimitFromHeaders(response.headers as unknown as Record<string, string>);
-			}
-
-			const pulls = response.data as unknown as GitHubPull[];
-			let allOlderThanSince = true;
-
-			for (const pr of pulls) {
-				if (pr.updated_at && (pr.updated_at as string) >= since) {
-					allOlderThanSince = false;
-					if (pr.draft === false && (pr.updated_at as string) > since) {
-						events.push(normalizePullRequestReadyForReview(this.sourceId, pr, repoData));
-					}
-				}
-			}
-
-			if (allOlderThanSince && pulls.length > 0) {
-				break;
-			}
-		}
-
-		return events;
 	}
 
 	private async pollFailedWorkflowRuns(since: string): Promise<OrgLoopEvent[]> {

--- a/connectors/linear/package.json
+++ b/connectors/linear/package.json
@@ -12,8 +12,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@orgloop/sdk": "workspace:*",
-    "@linear/sdk": "^75.0.0"
+    "@orgloop/sdk": "workspace:*"
   },
   "orgloop": {
     "type": "connector",

--- a/connectors/linear/src/graphql.ts
+++ b/connectors/linear/src/graphql.ts
@@ -1,0 +1,189 @@
+/**
+ * Batched GraphQL queries for the Linear connector.
+ *
+ * Replaces the N+1 pattern of the @linear/sdk (separate requests for each
+ * issue relation) with a single query that fetches issues, their state,
+ * assignee, creator, labels, and comments inline.
+ */
+
+// ─── Response Types ──────────────────────────────────────────────────────────
+
+export interface BatchIssueNode {
+	id: string;
+	identifier: string;
+	title: string;
+	description: string | null;
+	url: string;
+	priority: number;
+	createdAt: string;
+	updatedAt: string;
+	state: { name: string } | null;
+	assignee: { name: string } | null;
+	creator: { name: string } | null;
+	labels: { nodes: Array<{ name: string }> };
+	comments: { nodes: Array<BatchCommentNode> };
+}
+
+export interface BatchCommentNode {
+	id: string;
+	body: string;
+	url: string;
+	createdAt: string;
+	user: { name: string } | null;
+}
+
+export interface BatchIssuesResponse {
+	team: {
+		issues: {
+			nodes: BatchIssueNode[];
+			pageInfo: {
+				hasNextPage: boolean;
+				endCursor: string | null;
+			};
+		};
+	};
+}
+
+// ─── Query ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build the batched GraphQL query for fetching issues with all relations.
+ * Includes an optional project filter and comment-since filter.
+ */
+function buildBatchQuery(opts: { hasProject: boolean; hasCommentsSince: boolean }): string {
+	const projectFilter = opts.hasProject ? ', project: { name: { eq: $projectName } }' : '';
+	const commentsFilter = opts.hasCommentsSince
+		? '(filter: { createdAt: { gte: $commentsSince } }, first: 50)'
+		: '(first: 50)';
+
+	return `
+    query BatchPollIssues(
+      $teamId: String!
+      $since: DateTime!
+      ${opts.hasProject ? '$projectName: String!' : ''}
+      ${opts.hasCommentsSince ? '$commentsSince: DateTime!' : ''}
+      $first: Int!
+      $after: String
+    ) {
+      team(id: $teamId) {
+        issues(
+          filter: { updatedAt: { gte: $since }${projectFilter} }
+          first: $first
+          after: $after
+        ) {
+          nodes {
+            id
+            identifier
+            title
+            description
+            url
+            priority
+            createdAt
+            updatedAt
+            state { name }
+            assignee { name }
+            creator { name }
+            labels { nodes { name } }
+            comments${commentsFilter} {
+              nodes {
+                id
+                body
+                url
+                createdAt
+                user { name }
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  `;
+}
+
+// ─── Execution ──────────────────────────────────────────────────────────────
+
+export interface BatchQueryOptions {
+	apiKey: string;
+	teamKey: string;
+	since: string;
+	projectName?: string;
+	first?: number;
+	cursor?: string;
+	/** Custom fetch function (e.g. with HTTP keep-alive). Falls back to global fetch. */
+	fetch?: typeof globalThis.fetch;
+}
+
+/**
+ * Execute the batch GraphQL query against Linear's API.
+ * Returns issues with all relations inline (state, assignee, creator, labels, comments).
+ */
+export async function executeBatchQuery(opts: BatchQueryOptions): Promise<BatchIssuesResponse> {
+	const hasProject = !!opts.projectName;
+	const query = buildBatchQuery({ hasProject, hasCommentsSince: true });
+
+	const variables: Record<string, unknown> = {
+		teamId: opts.teamKey,
+		since: opts.since,
+		first: opts.first ?? 50,
+	};
+
+	if (opts.cursor) {
+		variables.after = opts.cursor;
+	}
+
+	if (hasProject) {
+		variables.projectName = opts.projectName;
+	}
+
+	variables.commentsSince = opts.since;
+
+	const fetchFn = opts.fetch ?? globalThis.fetch;
+	const response = await fetchFn('https://api.linear.app/graphql', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: opts.apiKey,
+		},
+		body: JSON.stringify({ query, variables }),
+	});
+
+	if (response.status === 429) {
+		throw Object.assign(new Error('Rate limited'), { status: 429 });
+	}
+
+	if (response.status === 401 || response.status === 403) {
+		throw Object.assign(new Error(`Auth error: ${response.statusText}`), {
+			status: response.status,
+		});
+	}
+
+	if (!response.ok) {
+		throw new Error(`Linear API error: ${response.status} ${response.statusText}`);
+	}
+
+	const json = (await response.json()) as {
+		data?: BatchIssuesResponse;
+		errors?: Array<{ message: string; extensions?: { code?: string } }>;
+	};
+
+	// Check for GraphQL-level errors (e.g. RATE_LIMITED extension)
+	if (json.errors?.length) {
+		const rateLimited = json.errors.some((e) => e.extensions?.code === 'RATE_LIMITED');
+		if (rateLimited) {
+			throw Object.assign(new Error('Rate limited'), {
+				extensions: { code: 'RATE_LIMITED' },
+			});
+		}
+		throw new Error(`Linear GraphQL error: ${json.errors[0].message}`);
+	}
+
+	if (!json.data) {
+		throw new Error('Linear API returned no data');
+	}
+
+	return json.data;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,9 +69,6 @@ importers:
 
   connectors/linear:
     dependencies:
-      '@linear/sdk':
-        specifier: ^75.0.0
-        version: 75.0.0(graphql@15.10.1)
       '@orgloop/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
@@ -497,11 +494,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@graphql-typed-document-node/core@3.2.0':
-    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
   '@inquirer/ansi@2.0.3':
     resolution: {integrity: sha512-g44zhR3NIKVs0zUesa4iMzExmZpLUdTLRMCStqX3GE5NT6VkPcxQGJ+uC8tDgBUC/vB1rUhUd55cOf++4NZcmw==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
@@ -638,10 +630,6 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
-
-  '@linear/sdk@75.0.0':
-    resolution: {integrity: sha512-gf/xmbiWc4cLHjoeOGCNVTglpy+M+ENHpP3bvU57wxD17s7j8zJGXp4wOStnRcQYR0FT+n/76fPp+XR3ZtEjDw==}
-    engines: {node: '>=18.x'}
 
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
@@ -1069,10 +1057,6 @@ packages:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
     engines: {node: '>=18'}
 
-  graphql@15.10.1:
-    resolution: {integrity: sha512-BL/Xd/T9baO6NFzoMpiMD7YUZ62R6viR5tp/MULVEnbYJXZA//kRNW7J0j1w/wXArgL0sCxhDfK5dczSKn3+cg==}
-    engines: {node: '>= 10.x'}
-
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -1484,10 +1468,6 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@graphql-typed-document-node/core@3.2.0(graphql@15.10.1)':
-    dependencies:
-      graphql: 15.10.1
-
   '@inquirer/ansi@2.0.3': {}
 
   '@inquirer/checkbox@5.1.0(@types/node@25.3.0)':
@@ -1608,12 +1588,6 @@ snapshots:
       '@types/node': 25.3.0
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
-
-  '@linear/sdk@75.0.0(graphql@15.10.1)':
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@15.10.1)
-    transitivePeerDependencies:
-      - graphql
 
   '@octokit/auth-token@6.0.0': {}
 
@@ -2007,8 +1981,6 @@ snapshots:
     optional: true
 
   get-east-asian-width@1.4.0: {}
-
-  graphql@15.10.1: {}
 
   iconv-lite@0.7.2:
     dependencies:


### PR DESCRIPTION
## Summary

Replaces N+1 REST/SDK polling patterns with batch GraphQL queries for both GitHub and Linear connectors.

### Changes

**GitHub connector:**
- New `graphql.ts` with `executeBatchPRQuery()` — fetches PRs + reviews in a single GraphQL query
- `source.ts` refactored to use batch result for all PR-related events
- REST retained for review comments, issue comments, workflow runs, check suites

**Linear connector:**
- New `graphql.ts` with `executeBatchQuery()` — fetches issues with state/assignee/creator/labels/comments inline
- Removes `@linear/sdk` dependency entirely
- `source.ts` refactored to use batch result

**Tests:**
- 45 GitHub tests + 28 Linear tests fully rewritten, mocking the new GraphQL layer
- Full suite passes (1047 tests)

### Verification
- ✅ Build passes
- ✅ All tests pass
- ✅ Typecheck passes
- ✅ Lint passes