### PR TITLE
feat(filter): add array-contains matching via [] path notation

### DIFF
--- a/connectors/github/src/normalizer.ts
+++ b/connectors/github/src/normalizer.ts
@@ -19,6 +19,15 @@ function extractPrAuthor(pr: Record<string, unknown>): string {
 	return (prUser?.login as string) ?? 'unknown';
 }
 
+/** Extract label names from a PR/issue as simple objects for filter matching */
+function extractLabels(obj: Record<string, unknown>): Array<{ name: string }> {
+	const labels = obj.labels as Array<Record<string, unknown>> | undefined;
+	if (!Array.isArray(labels)) return [];
+	return labels
+		.map((l) => ({ name: (l.name as string) ?? '' }))
+		.filter((l) => l.name !== '');
+}
+
 /** Normalize a PR review event */
 export function normalizePullRequestReview(
 	sourceId: string,
@@ -53,6 +62,7 @@ export function normalizePullRequestReview(
 			review_body: review.body,
 			pr_title: pr.title,
 			pr_number: pr.number,
+			labels: extractLabels(pr),
 		},
 	});
 }
@@ -89,6 +99,7 @@ export function normalizePullRequestReviewComment(
 			pr_number: pr.number,
 			diff_hunk: comment.diff_hunk,
 			path: comment.path,
+			labels: extractLabels(pr),
 		},
 	});
 }
@@ -159,6 +170,7 @@ export function normalizePullRequestClosed(
 			pr_number: pr.number,
 			merged,
 			merged_by: merged ? ((pr.merged_by as Record<string, unknown>)?.login as string) : undefined,
+			labels: extractLabels(pr),
 		},
 	});
 }
@@ -227,6 +239,7 @@ export function normalizePullRequestOpened(
 			draft: pr.draft ?? false,
 			head_ref: pr.head ? (pr.head as Record<string, unknown>).ref : undefined,
 			base_ref: pr.base ? (pr.base as Record<string, unknown>).ref : undefined,
+			labels: extractLabels(pr),
 		},
 	});
 }
@@ -261,6 +274,7 @@ export function normalizePullRequestReadyForReview(
 			pr_number: pr.number,
 			head_ref: pr.head ? (pr.head as Record<string, unknown>).ref : undefined,
 			base_ref: pr.base ? (pr.base as Record<string, unknown>).ref : undefined,
+			labels: extractLabels(pr),
 		},
 	});
 }


### PR DESCRIPTION
Adds support for filtering on array fields using [] notation in both the route filter (router.ts) and the transform filter (matcher.ts).

Syntax:
  payload.labels[].name: 'niko-authored'
  → matches if any element in payload.labels has .name === 'niko-authored'

  payload.tags[]: 'urgent'
  → matches if 'urgent' is an element of payload.tags

Also includes labels in the GitHub connector's normalized event payload for all PR-related events (reviews, comments, opened, closed, merged, ready_for_review). This enables label-based route filtering without additional API calls.

This enables filtering GitHub PR events by label at the route/transform level, avoiding unnecessary session spawns for events on PRs that don't have the agent's label. Previously, label filtering could only happen inside the SOP (after session spawn + API call).

Works with all filter modes: match, match_any, exclude.

Includes tests for router and transform-filter.

## Summary

Brief description of the changes.

## Related Issue

Closes #

## Changes Made

-

## Testing

- [ ] Tests pass locally (`pnpm test`)
- [ ] Linting passes (`pnpm run lint`)
- [ ] TypeScript compiles (`pnpm typecheck`)
- [ ] Tested manually (if applicable)

---

- [ ] I used AI tools to help write this PR
