### PR TITLE
docs: Patterns & Recipes + Transform Filter Deep Dive

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -34,6 +34,8 @@ export default defineConfig({
 				{
 					label: 'Guides',
 					items: [
+						{ label: 'Patterns & Recipes', slug: 'guides/patterns' },
+						{ label: 'Transform Filter Deep Dive', slug: 'guides/transform-filter' },
 						{ label: 'Building Connectors', slug: 'guides/connector-authoring' },
 						{ label: 'Building Transforms', slug: 'guides/transform-authoring' },
 						{ label: 'Project Setup', slug: 'guides/project-setup' },

--- a/docs-site/src/content/docs/guides/patterns.md
+++ b/docs-site/src/content/docs/guides/patterns.md
@@ -1,0 +1,559 @@
+---
+title: Patterns & Recipes
+description: Common automation patterns implemented with existing OrgLoop primitives. No new code needed.
+---
+
+OrgLoop's five primitives — sources, actors, routes, transforms, loggers — compose into surprisingly powerful patterns. This page shows how to solve common needs using what already exists, so you reach for the right tool instead of adding surface area.
+
+Every recipe below uses standard YAML config and built-in transforms. No custom code required unless stated otherwise.
+
+## Filtering by array fields (labels, assignees)
+
+**Problem:** You want to route events only when a PR has a specific label, or when an issue is assigned to someone on your team.
+
+**Solution:** Use the [transform-filter](/guides/transform-filter/) in jq mode. The `any` function is your friend for arrays.
+
+```yaml
+# Only events where the PR has the "needs-review" label
+transforms:
+  - name: has-needs-review-label
+    type: package
+    package: "@orgloop/transform-filter"
+    config:
+      jq: '.payload.labels | any(.name == "needs-review")'
+```
+
+```yaml
+# Only events where the assignee is on the platform team
+transforms:
+  - name: platform-team-only
+    type: package
+    package: "@orgloop/transform-filter"
+    config:
+      jq: '.payload.assignees | any(.login == "alice" or .login == "bob")'
+```
+
+Why jq? The basic `match`/`exclude` modes use dot-path field matching — great for scalar fields, but they can't inspect array elements. jq gives you full query power over nested structures. See the [transform-filter deep dive](/guides/transform-filter/) for the full capability breakdown.
+
+## Ownership-based filtering (only my PRs)
+
+**Problem:** You only want events related to PRs you authored, or that a specific bot created.
+
+**Solution:** Use `match_any` with comma-separated authors, or jq for complex ownership logic.
+
+### Simple: match by PR author
+
+```yaml
+transforms:
+  - name: my-prs-only
+    type: package
+    package: "@orgloop/transform-filter"
+    config:
+      match_any:
+        provenance.pr_author: "alice,bob"  # Comma-separated = OR matching
+```
+
+The filter automatically expands comma-separated values to arrays, so `"alice,bob"` means "alice OR bob". This is especially useful with environment variables:
+
+```yaml
+config:
+  match_any:
+    provenance.pr_author: "${MY_GITHUB_USERNAMES}"  # Set MY_GITHUB_USERNAMES=alice,bot-alice
+```
+
+### Complex: combine author + org membership
+
+```yaml
+transforms:
+  - name: team-ownership
+    type: package
+    package: "@orgloop/transform-filter"
+    config:
+      jq: >
+        .provenance.pr_author == "alice" or
+        .provenance.pr_author == "bob" or
+        (.payload.labels | any(.name == "team-platform"))
+```
+
+## Multi-agent routing (different SOPs per event type)
+
+**Problem:** Different event types need different agent behaviors. PR reviews need a code review SOP, CI failures need a debugging SOP, new tickets need a triage SOP.
+
+**Solution:** This is what routes are for. Define multiple routes from the same source, each with a different `when.filter` and `with.prompt_file`.
+
+```yaml
+routes:
+  # PR reviews → code review agent with review SOP
+  - name: pr-review
+    when:
+      source: github
+      events: [resource.changed]
+      filter:
+        provenance.platform_event: pull_request.review_submitted
+    then:
+      actor: engineering-agent
+    with:
+      prompt_file: ./sops/pr-review.md
+
+  # CI failures → same agent, different SOP
+  - name: ci-failure
+    when:
+      source: github
+      events: [resource.changed]
+      filter:
+        provenance.platform_event: workflow_run.completed
+    transforms:
+      - ref: ci-failure-filter  # Only failed runs
+    then:
+      actor: engineering-agent
+    with:
+      prompt_file: ./sops/ci-failure.md
+
+  # Linear tickets → triage agent
+  - name: new-ticket
+    when:
+      source: linear
+      events: [resource.changed]
+    then:
+      actor: triage-agent
+    with:
+      prompt_file: ./sops/triage.md
+```
+
+Key insight: the route's `when.filter` does coarse routing (event type, platform event), while transforms do fine-grained filtering (author, labels, priority). Use both together:
+
+```yaml
+# Route filter: only PR review events from GitHub
+when:
+  source: github
+  events: [resource.changed]
+  filter:
+    provenance.platform_event: pull_request.review_submitted
+
+# Transform filter: only from team members, excluding bots
+transforms:
+  - ref: team-members-only
+  - ref: drop-bot-noise
+```
+
+Route filters run before the transform pipeline, so they're more efficient for coarse decisions. See [Config Schema — Route Definition](/reference/config-schema/#route-definition) for the full `when.filter` reference.
+
+## One event, multiple actors
+
+**Problem:** A single event should trigger work from multiple actors — e.g., a PR merge should notify Slack AND update a dashboard AND trigger a deploy review.
+
+**Solution:** Define multiple routes matching the same event. Each route delivers to a different actor independently.
+
+```yaml
+routes:
+  - name: pr-merge-notify
+    when:
+      source: github
+      events: [resource.changed]
+      filter:
+        provenance.platform_event: pull_request.merged
+    then:
+      actor: slack-notifier
+
+  - name: pr-merge-dashboard
+    when:
+      source: github
+      events: [resource.changed]
+      filter:
+        provenance.platform_event: pull_request.merged
+    then:
+      actor: dashboard-updater
+
+  - name: pr-merge-deploy-review
+    when:
+      source: github
+      events: [resource.changed]
+      filter:
+        provenance.platform_event: pull_request.merged
+    transforms:
+      - ref: production-branch-only
+    then:
+      actor: deploy-reviewer
+    with:
+      prompt_file: ./sops/deploy-review.md
+```
+
+OrgLoop evaluates all routes for every event. One event can match multiple routes and be delivered to multiple actors. Each route's transform pipeline runs independently.
+
+## Deduplication patterns
+
+**Problem:** The same event keeps arriving — GitHub sends the same PR data on every poll, or a webhook fires twice for the same change.
+
+**Solution:** Use the built-in `@orgloop/transform-dedup` transform. It hashes configurable fields and drops duplicates within a time window.
+
+### Basic: deduplicate by event identity
+
+```yaml
+transforms:
+  - name: dedup
+    type: package
+    package: "@orgloop/transform-dedup"
+    config:
+      key:
+        - source
+        - type
+        - payload.pr_number
+      window: 5m
+```
+
+This drops events where the combination of `source` + `type` + `payload.pr_number` was already seen within the last 5 minutes.
+
+### Per-route dedup with different keys
+
+Different routes may need different dedup strategies. A PR review route deduplicates on the review ID, while a CI route deduplicates on the run ID:
+
+```yaml
+# In the route definition, override the transform config
+routes:
+  - name: pr-reviews
+    transforms:
+      - ref: dedup
+        config:
+          key: [source, payload.review_id]
+          window: 10m
+    # ...
+
+  - name: ci-runs
+    transforms:
+      - ref: dedup
+        config:
+          key: [source, payload.run_id]
+          window: 30m
+    # ...
+```
+
+### Wider windows for batch processing
+
+If your actor processes events in batches (e.g., daily digest), use a longer window:
+
+```yaml
+config:
+  key: [source, type, payload.pr_number]
+  window: 24h
+```
+
+## Environment variable interpolation
+
+**Problem:** You want to parameterize filter values, author lists, or thresholds without hardcoding them in YAML.
+
+**Solution:** Use `${VAR_NAME}` syntax in any config value. The config loader resolves env vars before transforms see them.
+
+```yaml
+transforms:
+  - name: team-filter
+    type: package
+    package: "@orgloop/transform-filter"
+    config:
+      match_any:
+        provenance.pr_author: "${TEAM_MEMBERS}"    # e.g., alice,bob,charlie
+      exclude:
+        provenance.author: "${EXCLUDED_BOTS}"       # e.g., dependabot[bot],renovate[bot]
+```
+
+```bash
+# .env
+TEAM_MEMBERS=alice,bob,charlie
+EXCLUDED_BOTS=dependabot[bot],renovate[bot]
+```
+
+Comma-separated values from env vars are automatically expanded to arrays by the filter transform. This means `TEAM_MEMBERS=alice,bob,charlie` becomes a three-element OR match.
+
+Use `orgloop env` to verify your variables are set correctly before starting.
+
+## Transform composition (defense-in-depth pipelines)
+
+**Problem:** You need multiple filtering and enrichment steps — drop bots, deduplicate, filter by team, add metadata.
+
+**Solution:** Chain transforms in your route definition. They execute sequentially, and each one can drop the event.
+
+```yaml
+routes:
+  - name: team-pr-reviews
+    when:
+      source: github
+      events: [resource.changed]
+      filter:
+        provenance.platform_event: pull_request.review_submitted
+    transforms:
+      - ref: drop-bot-noise       # 1. Drop bot-authored events
+      - ref: dedup                 # 2. Deduplicate (only sees non-bot events)
+      - ref: team-members-only    # 3. Only team member PRs
+      - ref: add-team-metadata    # 4. Enrich with team info
+    then:
+      actor: engineering-agent
+    with:
+      prompt_file: ./sops/pr-review.md
+```
+
+The corresponding transform definitions:
+
+```yaml
+transforms:
+  - name: drop-bot-noise
+    type: package
+    package: "@orgloop/transform-filter"
+    config:
+      exclude:
+        provenance.author_type: bot
+
+  - name: dedup
+    type: package
+    package: "@orgloop/transform-dedup"
+    config:
+      key: [source, type, payload.pr_number]
+      window: 5m
+
+  - name: team-members-only
+    type: package
+    package: "@orgloop/transform-filter"
+    config:
+      match_any:
+        provenance.pr_author: "${TEAM_MEMBERS}"
+
+  - name: add-team-metadata
+    type: package
+    package: "@orgloop/transform-enrich"
+    config:
+      set:
+        metadata.team: "platform"
+      copy:
+        metadata.author: provenance.pr_author
+```
+
+Order matters. Filter early to reduce work for later transforms. The typical pipeline order:
+
+1. **Exclude** noise (bots, irrelevant events)
+2. **Dedup** to prevent reprocessing
+3. **Filter** to refine (team membership, priority, labels)
+4. **Enrich** with additional context
+
+## Enrichment patterns
+
+**Problem:** Events from connectors don't have all the context your actor needs — you want to add team names, copy fields to standard locations, or compute derived values.
+
+**Solution:** Use the `@orgloop/transform-enrich` transform.
+
+### Add static fields
+
+```yaml
+transforms:
+  - name: add-context
+    type: package
+    package: "@orgloop/transform-enrich"
+    config:
+      set:
+        metadata.team: "platform"
+        metadata.priority: "p1"
+        metadata.env: "${DEPLOYMENT_ENV}"
+```
+
+### Copy fields to standard locations
+
+```yaml
+config:
+  copy:
+    metadata.author: provenance.pr_author
+    metadata.repo: provenance.repo
+    metadata.event_kind: provenance.platform_event
+```
+
+### Compute derived fields
+
+```yaml
+config:
+  compute:
+    metadata.is_bot: "provenance.author_type === 'bot'"
+    metadata.is_critical: "payload.priority > 8"
+    metadata.needs_review: "payload.status === 'open'"
+```
+
+Compute supports comparison operators (`===`, `!==`, `>`, `<`, `>=`, `<=`). The result is a boolean. Use `set` for static values and `copy` for field relocation.
+
+## Route-level filtering with CWD patterns
+
+**Problem:** You use Claude Code across multiple projects and want different routing per project directory.
+
+**Solution:** The Claude Code connector emits the working directory in `payload.cwd`. Use regex patterns in the transform-filter to route by path.
+
+```yaml
+transforms:
+  - name: work-projects-only
+    type: package
+    package: "@orgloop/transform-filter"
+    config:
+      match:
+        payload.cwd: '/^\/Users\/alice\/work\//'
+
+  - name: personal-projects-only
+    type: package
+    package: "@orgloop/transform-filter"
+    config:
+      match:
+        payload.cwd: '/\/personal\//'
+```
+
+Regex patterns are delimited with forward slashes: `/pattern/flags`. Case-insensitive matching uses the `i` flag: `/pattern/i`.
+
+## Token refresh for expiring credentials
+
+**Problem:** Some APIs use short-lived tokens that expire (e.g., GitHub App installation tokens, OAuth refresh flows).
+
+**Solution:** OrgLoop doesn't manage token lifecycles directly — that's outside its scope ([scope boundaries](/vision/scope-boundaries/)). Instead, use an external credential manager that writes fresh tokens to the environment.
+
+### Pattern: external script + .env reload
+
+1. Write a credential refresh script that obtains a fresh token and writes it to `.env`:
+
+```bash
+#!/bin/bash
+# refresh-token.sh
+NEW_TOKEN=$(your-auth-cli get-token --app-id 12345)
+sed -i '' "s/^GITHUB_TOKEN=.*/GITHUB_TOKEN=${NEW_TOKEN}/" .env
+```
+
+2. Run it on a schedule (cron, launchd, systemd timer):
+
+```bash
+# crontab -e
+*/30 * * * * cd /path/to/orgloop-project && ./refresh-token.sh
+```
+
+3. OrgLoop reads `${GITHUB_TOKEN}` from the environment at config load time. Restart the daemon after token refresh, or use the config's `token_command` if your connector supports it.
+
+The key principle: OrgLoop routes events, it doesn't manage credentials. Keep credential lifecycle in dedicated tooling where it belongs.
+
+## Supervision loops (actor monitoring actor)
+
+**Problem:** You want one agent to review the output of another — a supervisor pattern.
+
+**Solution:** Use the `actor.stopped` event type. When an actor's session ends, OrgLoop emits an `actor.stopped` event that can be routed to a different actor.
+
+```yaml
+routes:
+  # Primary work: GitHub events → engineering agent
+  - name: engineering-work
+    when:
+      source: github
+      events: [resource.changed]
+    then:
+      actor: engineering-agent
+    with:
+      prompt_file: ./sops/engineering.md
+
+  # Supervision: engineering agent completes → supervisor reviews
+  - name: supervisor-review
+    when:
+      source: claude-code
+      events: [actor.stopped]
+    transforms:
+      - ref: engineering-sessions-only
+    then:
+      actor: supervisor-agent
+    with:
+      prompt_file: ./sops/supervisor.md
+```
+
+The supervisor agent receives the full `actor.stopped` event, including the session payload — what was worked on, exit status, and any output. The supervisor's SOP decides whether the work was adequate.
+
+See the [Multi-Agent Supervisor example](/examples/multi-agent-supervisor/) for a complete working configuration.
+
+## Debugging event flows
+
+**Problem:** Events aren't reaching your actor, or the wrong events are getting through. How do you figure out what's happening?
+
+**Solution:** Use OrgLoop's built-in observability tools.
+
+### See your routes
+
+```bash
+orgloop routes
+```
+
+Displays all configured routes with their sources, events, transforms, and targets in a visual table.
+
+### Check configuration health
+
+```bash
+orgloop validate    # Schema validation, file references, env vars
+orgloop doctor      # System health: dependencies, permissions, connectivity
+orgloop env         # Environment variable status (set/missing per connector)
+```
+
+### Preview what would happen
+
+```bash
+orgloop plan        # Dry-run showing what sources, routes, and actors would be created
+```
+
+### Inspect live event flow
+
+```bash
+orgloop logs --follow          # Stream all pipeline activity
+orgloop logs --event evt_xxx   # Trace a specific event through the pipeline
+orgloop status                 # Runtime status of sources, actors, routes
+```
+
+Every transform decision (pass, drop, error) is logged with the event's trace ID. If an event is being dropped by a transform, the logs will tell you which transform dropped it and why.
+
+## Script transforms for external API enrichment
+
+**Problem:** You want to enrich events with data from an external API — look up a Jira ticket, fetch a user profile, query a database.
+
+**Solution:** Write a script transform that calls the external API and merges the result into the event.
+
+```python
+#!/usr/bin/env python3
+# transforms/enrich-jira.py
+import sys, json, os, urllib.request
+
+event = json.load(sys.stdin)
+ticket_id = event.get("payload", {}).get("ticket_id")
+
+if not ticket_id:
+    json.dump(event, sys.stdout)  # No ticket, pass through
+    sys.exit(0)
+
+# Fetch from Jira
+api_token = os.environ.get("JIRA_API_TOKEN", "")
+url = f"https://your-org.atlassian.net/rest/api/3/issue/{ticket_id}"
+req = urllib.request.Request(url, headers={
+    "Authorization": f"Basic {api_token}",
+    "Accept": "application/json"
+})
+
+try:
+    resp = urllib.request.urlopen(req, timeout=5)
+    jira_data = json.loads(resp.read())
+    event.setdefault("metadata", {})["jira_priority"] = jira_data["fields"]["priority"]["name"]
+    event["metadata"]["jira_status"] = jira_data["fields"]["status"]["name"]
+except Exception:
+    pass  # Fail-open: if Jira is down, event passes through without enrichment
+
+json.dump(event, sys.stdout)
+```
+
+```yaml
+transforms:
+  - name: enrich-jira
+    type: script
+    script: ./transforms/enrich-jira.py
+    timeout_ms: 10000
+```
+
+Script transforms can be written in any language. They receive the full event on stdin and write the (optionally modified) event to stdout. See [Building Transforms — Script transforms](/guides/transform-authoring/#script-transforms) for the full contract.
+
+---
+
+## See also
+
+- [Transform Filter Deep Dive](/guides/transform-filter/) — full reference for match, match_any, exclude, jq, regex, and CSV expansion
+- [Building Transforms](/guides/transform-authoring/) — how to build script and package transforms
+- [Config Schema — Route Definition](/reference/config-schema/#route-definition) — route filter and transform reference
+- [Config Schema — Environment Variables](/reference/config-schema/#environment-variable-substitution) — `${VAR}` syntax
+- [Multi-Agent Supervisor Example](/examples/multi-agent-supervisor/) — complete supervision loop config
+- [Engineering Org Example](/examples/engineering-org/) — full production routing setup

--- a/docs-site/src/content/docs/guides/transform-authoring.md
+++ b/docs-site/src/content/docs/guides/transform-authoring.md
@@ -210,7 +210,7 @@ OrgLoop ships three built-in transforms:
 
 ### `@orgloop/transform-filter`
 
-General-purpose event filter with dot-path field matching and optional jq mode.
+General-purpose event filter with dot-path field matching, regex patterns, CSV expansion, and a full jq mode escape hatch.
 
 ```yaml
 transforms:
@@ -235,11 +235,19 @@ transforms:
           - "dependabot[bot]"
           - "renovate[bot]"
 
-  # jq mode -- full jq expression (requires jq installed)
+  # Regex patterns -- match by pattern
   - ref: filter
     config:
-      jq: '.provenance.author_type == "team_member"'
+      match:
+        payload.cwd: '/^\/Users\/alice\/work\//'
+
+  # jq mode -- full jq expression for anything match/exclude can't do
+  - ref: filter
+    config:
+      jq: '.payload.labels | any(.name == "needs-review")'
 ```
+
+The filter supports exact values, arrays, regex (`/pattern/flags`), comma-separated value expansion (useful with `${ENV_VARS}`), and jq as the escape hatch for complex logic like array-contains checks. See the [Transform Filter Deep Dive](/guides/transform-filter/) for the complete reference.
 
 ### `@orgloop/transform-dedup`
 
@@ -296,3 +304,8 @@ expect(result).not.toBeNull();
 ```
 
 See the [Building Connectors](/guides/connector-authoring/) guide for the full SDK test harness API.
+
+## See also
+
+- [Transform Filter Deep Dive](/guides/transform-filter/) — complete reference for match, match_any, exclude, jq, regex, and CSV expansion
+- [Patterns & Recipes](/guides/patterns/) — common filtering and enrichment patterns with complete YAML examples

--- a/docs-site/src/content/docs/guides/transform-filter.md
+++ b/docs-site/src/content/docs/guides/transform-filter.md
@@ -1,0 +1,330 @@
+---
+title: Transform Filter Deep Dive
+description: Complete reference for the built-in transform-filter — match, match_any, exclude, jq, regex, CSV expansion, and dot-path notation.
+---
+
+The `@orgloop/transform-filter` is OrgLoop's built-in event filter. It handles the vast majority of filtering needs without writing code — from simple field matching to full jq expressions. Understanding its capabilities means you rarely need to build a custom filter.
+
+## Two modes
+
+The filter operates in one of two modes:
+
+1. **Match/Exclude mode** — Declarative dot-path field matching. Fast, in-process, no dependencies.
+2. **jq mode** — Full jq expression evaluation. Subprocess-based, requires `jq` installed. The escape hatch for anything match/exclude can't do.
+
+If both are specified, **jq takes precedence** and match/exclude are ignored.
+
+## Match/Exclude mode
+
+Three operations, evaluated in this order:
+
+| Operation | Logic | Effect |
+|-----------|-------|--------|
+| `exclude` | OR — any criterion matching drops the event | Runs first. If any exclusion matches, event is dropped immediately. |
+| `match` | AND — all criteria must match | Runs second. All criteria must pass for the event to continue. |
+| `match_any` | OR — any criterion matching keeps the event | Runs third. At least one criterion must pass. |
+
+All three can be combined in a single filter. The evaluation order is always exclude → match → match_any, regardless of YAML field order.
+
+### Basic match (AND)
+
+All criteria must match. Use this for "keep only events that look like X."
+
+```yaml
+transforms:
+  - name: human-pr-reviews
+    type: package
+    package: "@orgloop/transform-filter"
+    config:
+      match:
+        type: "resource.changed"
+        provenance.platform_event: "pull_request.review_submitted"
+        provenance.author_type: "team_member"
+```
+
+This passes events that are `resource.changed` AND are PR review submissions AND are from a team member. All three must be true.
+
+### Match any (OR)
+
+At least one criterion must match. Use this for "keep events matching any of these."
+
+```yaml
+config:
+  match_any:
+    provenance.pr_author: "alice"
+    provenance.reviewer: "bob"
+```
+
+This passes events where the PR author is alice OR the reviewer is bob.
+
+### Exclude (OR)
+
+Any criterion matching drops the event. Use this for "drop events matching any of these."
+
+```yaml
+config:
+  exclude:
+    provenance.author:
+      - "dependabot[bot]"
+      - "renovate[bot]"
+    provenance.author_type: "bot"
+```
+
+This drops events where the author is dependabot OR renovate OR the author type is bot. Any single match drops the event.
+
+### Combining all three
+
+```yaml
+config:
+  exclude:
+    provenance.author_type: "bot"
+  match:
+    type: "resource.changed"
+  match_any:
+    provenance.pr_author: "alice,bob"
+    provenance.reviewer: "charlie"
+```
+
+Evaluation: First, if the author type is bot → dropped. Then, event must be `resource.changed`. Then, the PR author must be alice or bob, OR the reviewer must be charlie.
+
+## Dot-path notation
+
+All field references use dot-separated paths to traverse nested objects.
+
+| Path | Resolves to |
+|------|-------------|
+| `type` | `event.type` |
+| `source` | `event.source` |
+| `provenance.author` | `event.provenance.author` |
+| `provenance.author_type` | `event.provenance.author_type` |
+| `payload.pr_number` | `event.payload.pr_number` |
+| `payload.labels` | `event.payload.labels` (array) |
+
+If any segment in the path is missing or not an object, the value is treated as undefined and won't match any pattern (safe, no crash).
+
+## Pattern types
+
+The filter supports several pattern types for matching field values.
+
+### Exact value
+
+Strings, numbers, and booleans use strict equality.
+
+```yaml
+match:
+  type: "resource.changed"          # String
+  payload.count: 42                  # Number
+  payload.draft: false               # Boolean
+```
+
+### Array patterns (any-match)
+
+An array in a pattern means "match if the field equals any element."
+
+```yaml
+exclude:
+  provenance.author:
+    - "dependabot[bot]"
+    - "renovate[bot]"
+    - "github-actions[bot]"
+```
+
+This drops the event if `provenance.author` equals any of those three values.
+
+### Comma-separated values (CSV expansion)
+
+String values containing commas are automatically expanded to arrays during initialization. This is especially useful with environment variable substitution.
+
+```yaml
+match_any:
+  provenance.pr_author: "alice,bob,charlie"
+```
+
+Is equivalent to:
+
+```yaml
+match_any:
+  provenance.pr_author:
+    - "alice"
+    - "bob"
+    - "charlie"
+```
+
+Whitespace around commas is trimmed. Combined with env vars:
+
+```yaml
+match_any:
+  provenance.pr_author: "${TEAM_MEMBERS}"   # TEAM_MEMBERS=alice,bob,charlie
+exclude:
+  provenance.author: "${EXCLUDED_BOTS}"      # EXCLUDED_BOTS=dependabot[bot],renovate[bot]
+```
+
+### Regex patterns
+
+Wrap a pattern in forward slashes for regular expression matching.
+
+```yaml
+match:
+  payload.cwd: '/^\/Users\/alice\/work\//'       # Path starts with /Users/alice/work/
+  payload.title: '/fix|bug/i'                     # Case-insensitive match for "fix" or "bug"
+  payload.branch: '/^feature\//'                  # Branch starts with feature/
+```
+
+Syntax: `/pattern/flags` where flags are optional. Supported flags include `i` (case-insensitive).
+
+If the regex is invalid, the filter falls back to exact string matching (safe failure).
+
+### Null matching
+
+```yaml
+match:
+  provenance.reviewer: null     # Matches when reviewer is null or undefined
+```
+
+## jq mode — the escape hatch
+
+When match/exclude can't express what you need, jq mode gives you the full power of jq expressions. This is the answer to "how do I filter on X?" for any X.
+
+### Setup
+
+jq mode requires `jq` installed on the system (`brew install jq`, `apt install jq`, etc.).
+
+```yaml
+transforms:
+  - name: complex-filter
+    type: package
+    package: "@orgloop/transform-filter"
+    config:
+      jq: '<jq expression>'
+```
+
+### How it works
+
+The filter pipes the entire event JSON to `jq -e '<expression>'` as a subprocess (5-second timeout).
+
+| jq output | Result |
+|-----------|--------|
+| Exit 0, valid JSON object with `id` field | Event replaced with jq output |
+| Exit 0, truthy non-JSON output | Event passes unchanged |
+| Exit 0, `null` or `false` | Event dropped |
+| Non-zero exit | Event dropped |
+| Timeout (5s) | Event dropped |
+
+### Boolean filter (most common)
+
+The expression evaluates to true/false. True keeps the event unchanged, false drops it.
+
+```yaml
+# Filter by array contents
+config:
+  jq: '.payload.labels | any(.name == "needs-review")'
+```
+
+```yaml
+# Filter by author with OR logic
+config:
+  jq: '.provenance.pr_author == "alice" or .provenance.pr_author == "bob"'
+```
+
+```yaml
+# Complex: array contains + author check
+config:
+  jq: >
+    (.payload.labels | any(.name == "urgent")) and
+    .provenance.author_type == "team_member"
+```
+
+```yaml
+# Negative: exclude events with "wip" label
+config:
+  jq: '(.payload.labels | any(.name == "wip")) | not'
+```
+
+### Computed filter (field transformations)
+
+jq can also transform the event. If the output is a valid JSON object with an `id` field, it replaces the original event.
+
+```yaml
+# Add a computed field and pass through
+config:
+  jq: '. + {metadata: {label_count: (.payload.labels | length)}}'
+```
+
+### Real-world examples
+
+**Only PR reviews from non-bot authors on non-draft PRs:**
+
+```yaml
+config:
+  jq: >
+    .provenance.author_type != "bot" and
+    (.payload.draft | not) and
+    .provenance.platform_event == "pull_request.review_submitted"
+```
+
+**Only events where the PR has specific labels:**
+
+```yaml
+config:
+  jq: '.payload.labels | any(.name == "niko-authored")'
+```
+
+**Only events from specific authors:**
+
+```yaml
+config:
+  jq: '.provenance.pr_author == "doink-kindo[bot]" or .provenance.pr_author == "c-h-"'
+```
+
+**Filter CI failures (exclude successes):**
+
+```yaml
+config:
+  jq: '.payload.conclusion == "failure" or .payload.conclusion == "timed_out"'
+```
+
+**Array intersection (PR has any of these labels):**
+
+```yaml
+config:
+  jq: '[.payload.labels[].name] | any(. == "bug" or . == "critical" or . == "security")'
+```
+
+## When to use which mode
+
+| Need | Mode | Example |
+|------|------|---------|
+| Match a single field value | `match` | `provenance.author_type: team_member` |
+| Match one of several values | `match` with array | `provenance.author: [alice, bob]` |
+| Match any of several fields | `match_any` | Author OR reviewer matches |
+| Exclude specific values | `exclude` | Drop bot authors |
+| Match by regex pattern | `match` with regex | `payload.cwd: '/\/work\//'` |
+| Parameterize with env vars | `match` + CSV expansion | `${TEAM_MEMBERS}` |
+| Inspect array elements | `jq` | Labels contain "needs-review" |
+| Complex boolean logic | `jq` | Author AND label AND NOT draft |
+| Transform the event | `jq` | Add computed fields |
+
+**Rule of thumb:** Start with match/exclude. If you find yourself needing to inspect array elements or combine complex boolean logic, switch to jq. jq is the escape hatch — it can express anything.
+
+## No config = pass-all
+
+If no match, exclude, match_any, or jq is configured, the filter passes all events unchanged. This means you can add the filter to a pipeline and configure it later.
+
+## Error handling
+
+The filter is designed to be safe:
+
+- **Invalid regex** → falls back to exact string match
+- **Missing jq binary** → event dropped (logged as error)
+- **jq timeout (5s)** → event dropped (logged as error)
+- **Missing dot-path segments** → treated as undefined (no match, no crash)
+
+The filter follows OrgLoop's fail-open philosophy for match/exclude mode (missing fields just don't match). jq mode fails closed (errors drop events) because jq errors typically indicate a logic problem that should be fixed.
+
+---
+
+## See also
+
+- [Patterns & Recipes](/guides/patterns/) — common filtering patterns with complete YAML examples
+- [Building Transforms](/guides/transform-authoring/) — script and package transform authoring guide
+- [Config Schema — Transform Definition](/reference/config-schema/#transform-definition) — YAML config reference

--- a/docs-site/src/content/docs/reference/config-schema.md
+++ b/docs-site/src/content/docs/reference/config-schema.md
@@ -267,13 +267,15 @@ routes:
 | `when.events` | string[] | Yes | Event types to match (e.g., `resource.changed`). |
 | `when.filter` | object | No | Dot-path filter on event fields. All conditions must match. |
 
-Filter uses dot-path notation to match nested event fields:
+Filter uses dot-path notation to match nested event fields (all conditions must match):
 
 ```yaml
 filter:
   provenance.platform_event: pull_request.review_submitted
   provenance.author_type: team_member
 ```
+
+Route-level filters support exact value matching only. For regex patterns, array-contains logic, or complex boolean expressions, use the [transform-filter](/guides/transform-filter/) in your route's transform pipeline instead.
 
 ### `transforms` — Pipeline
 


### PR DESCRIPTION
## Summary

- **New: Patterns & Recipes guide** (`guides/patterns.md`) — 12 common automation patterns implemented with existing OrgLoop primitives, no new code needed. Covers array filtering (jq), ownership-based routing, multi-agent routing, one-event-multiple-actors, dedup patterns, env var interpolation, transform composition, enrichment, CWD-based routing, token refresh, supervision loops, and debugging event flows.
- **New: Transform Filter Deep Dive** (`guides/transform-filter.md`) — Complete reference for the built-in `@orgloop/transform-filter`: match (AND), match_any (OR), exclude (OR-drop), jq mode as the escape hatch, regex patterns, CSV expansion, dot-path notation, evaluation order, and error handling.
- **Updated: Building Transforms guide** — Cross-linked to new filter deep dive, expanded the filter section with regex and jq examples.
- **Updated: Config Schema reference** — Added note on route-level filter limitations and pointer to transform-filter for advanced filtering.
- **Updated: Sidebar nav** — Both new pages at top of Guides section for discoverability.

## Motivation

Contributors were proposing features (array-contains matching, new filter modes) that existing primitives already solve — especially jq mode in transform-filter. The docs didn't make this power discoverable. These pages close that gap so contributors reach for the right patterns instead of adding surface area.

## Test plan

- [x] `npm run build` in docs-site succeeds (49 pages built)
- [x] Pre-push hooks pass (build, 1058 tests, typecheck, lint)
- [x] All cross-links point to valid slugs
- [x] Both new pages appear in sidebar navigation


🤖 Generated with [Claude Code](https://claude.com/claude-code)