### PR TITLE
fix(cli): auto-register into running daemon without --daemon flag

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -598,6 +598,22 @@ async function startAction(
 				output.info(`Logs: ${LOG_DIR}`);
 			}
 		} else {
+			// Check for already-running daemon — auto-register if found (#46)
+			const daemonInfo = await getDaemonInfo();
+
+			if (daemonInfo) {
+				// Daemon is running — register this project's module into it
+				try {
+					await registerIntoRunningDaemon(daemonInfo.port, globalOpts.config as string | undefined);
+				} catch (err) {
+					output.error(
+						`Failed to register module: ${err instanceof Error ? err.message : String(err)}`,
+					);
+					process.exitCode = 1;
+				}
+				return;
+			}
+
 			await runForeground(globalOpts.config as string | undefined, opts.force);
 		}
 	} catch (err) {


### PR DESCRIPTION
## Summary

- When a daemon is already running, `orgloop start` (without `--daemon`) now detects it and auto-registers the current module via the control API
- Previously this would fail with EADDRINUSE because the foreground path tried to bind the same port
- The `--daemon` flag now only means "start as background daemon", not "enable daemon detection"

Closes #46

## Test plan

- [x] Added 4 regression tests in `daemon-lifecycle.test.ts` covering auto-register detection:
  - Detects running daemon via PID + port files
  - Falls through to foreground when no daemon running
  - Falls through to foreground when PID is stale
  - Falls through to foreground when port file is missing
- [x] All 227 CLI tests pass
- [x] Full monorepo build, typecheck, and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)