### PR TITLE
release: v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
   "dependencies": {
     "@orgloop/transform-agent-gate": "workspace:^"
   },
-  "version": "0.3.0"
+  "version": "0.4.0"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "OrgLoop command-line interface",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orgloop/core",
-  "version": "0.3.0",
-  "description": "OrgLoop runtime engine — library-first event routing",
+  "version": "0.4.0",
+  "description": "OrgLoop runtime engine \u2014 library-first event routing",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orgloop/sdk",
-  "version": "0.3.0",
-  "description": "OrgLoop plugin development kit — interfaces, base classes, and test harnesses",
+  "version": "0.4.0",
+  "description": "OrgLoop plugin development kit \u2014 interfaces, base classes, and test harnesses",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/server",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "OrgLoop HTTP API server",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## v0.4.0

### Features
- **Batch GraphQL polling** for GitHub and Linear connectors — replaces N+1 REST/SDK patterns (#58, closes #56)
- **HTTP keep-alive connection pooling** for all connectors (#59)

### Fixes
- **Auto-register into running daemon** — `orgloop start` now detects a running daemon and registers without `--daemon` (#63, closes #46)
- **fetchSinglePull retry** — prevents pr_author degradation to 'unknown' on transient errors (#60)

### Docs
- Patterns & Recipes guide — 12 automation patterns including jq escape hatch (#62)
- Transform Filter Deep Dive — full jq mode documentation (#62)