### PR TITLE
release: v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
       },
       "engines": {
         "node": ">=22.0.0"
-      }
+      },
+      "version": "0.5.0"
     },
     "node_modules/@biomejs/biome": {
       "version": "1.9.4",
@@ -1885,5 +1886,6 @@
         "node": ">=8"
       }
     }
-  }
+  },
+  "version": "0.5.0"
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
   "dependencies": {
     "@orgloop/transform-agent-gate": "workspace:^"
   },
-  "version": "0.4.0"
+  "version": "0.5.0"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "OrgLoop command-line interface",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orgloop/core",
-  "version": "0.4.0",
-  "description": "OrgLoop runtime engine \u2014 library-first event routing",
+  "version": "0.5.0",
+  "description": "OrgLoop runtime engine — library-first event routing",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orgloop/sdk",
-  "version": "0.4.0",
-  "description": "OrgLoop plugin development kit \u2014 interfaces, base classes, and test harnesses",
+  "version": "0.5.0",
+  "description": "OrgLoop plugin development kit — interfaces, base classes, and test harnesses",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/server",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "OrgLoop HTTP API server",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## v0.5.0 — Lifecycle Connector Epic

Normalized lifecycle events across all 5 coding harness connectors.

### New
- SDK lifecycle contract with `assertLifecycleConformance` test helper (#73)
- `connector-claude-code` + `connector-agent-ctl` lifecycle coverage (#68)
- `connector-codex` — webhook-based Codex session lifecycle (#69)
- `connector-opencode` — webhook-based OpenCode session lifecycle (#70)
- `connector-pi` — webhook-based Pi session lifecycle (#71)
- `connector-pi-rust` — webhook-based Pi-rust session lifecycle (#72)

### Lifecycle phases
`started → active → completed|failed|stopped`

All connectors emit backward-compatible payloads with normalized `payload.lifecycle` + `payload.session` fields.