### PR TITLE
fix(connector-linear): add issue_assignee to comment provenance

### DIFF
--- a/connectors/linear/src/__tests__/source.test.ts
+++ b/connectors/linear/src/__tests__/source.test.ts
@@ -393,6 +393,65 @@ describe('LinearSource', () => {
 			expect(comments[0].payload.comment_body).toBe('Looks good');
 			expect(comments[0].payload.issue_id).toBe('ENG-1');
 		});
+
+		it('includes issue_assignee and issue_creator in comment provenance', async () => {
+			const issue = makeIssueNode({
+				assignee: { name: 'Alice' },
+				creator: { name: 'Bob' },
+				createdAt: '2024-01-01T11:00:00.000Z',
+				updatedAt: '2024-01-01T12:05:00.000Z',
+				comments: [
+					{
+						id: 'comment-1',
+						body: 'Progress update',
+						url: 'https://linear.app/comment/1',
+						createdAt: '2024-01-01T12:02:00.000Z',
+						user: { name: 'Charlie' },
+					},
+				],
+			});
+			mockExecuteBatchQuery.mockResolvedValue(makeBatchResponse([issue]));
+			const source = await createSource();
+
+			const result = await source.poll('2024-01-01T12:00:00.000Z');
+
+			const comments = result.events.filter(
+				(e) => e.provenance.platform_event === 'comment.created',
+			);
+			expect(comments.length).toBe(1);
+			expect(comments[0].provenance.author).toBe('Charlie');
+			expect(comments[0].provenance.issue_assignee).toBe('Alice');
+			expect(comments[0].provenance.issue_creator).toBe('Bob');
+		});
+
+		it('sets issue_assignee to null when issue is unassigned', async () => {
+			const issue = makeIssueNode({
+				assignee: null,
+				creator: { name: 'Bob' },
+				createdAt: '2024-01-01T11:00:00.000Z',
+				updatedAt: '2024-01-01T12:05:00.000Z',
+				comments: [
+					{
+						id: 'comment-1',
+						body: 'Needs triage',
+						url: 'https://linear.app/comment/1',
+						createdAt: '2024-01-01T12:02:00.000Z',
+						user: { name: 'Alice' },
+					},
+				],
+			});
+			mockExecuteBatchQuery.mockResolvedValue(makeBatchResponse([issue]));
+			const source = await createSource();
+
+			const result = await source.poll('2024-01-01T12:00:00.000Z');
+
+			const comments = result.events.filter(
+				(e) => e.provenance.platform_event === 'comment.created',
+			);
+			expect(comments.length).toBe(1);
+			expect(comments[0].provenance.issue_assignee).toBeNull();
+			expect(comments[0].provenance.issue_creator).toBe('Bob');
+		});
 	});
 
 	// ─── State Cache Persistence ────────────────────────────────────────────

--- a/connectors/linear/src/normalizer.ts
+++ b/connectors/linear/src/normalizer.ts
@@ -54,6 +54,8 @@ export function normalizeComment(
 	issue: {
 		identifier: string;
 		title: string;
+		assignee?: { name: string } | null;
+		creator?: { name: string } | null;
 	},
 ): OrgLoopEvent {
 	return buildEvent({
@@ -65,6 +67,8 @@ export function normalizeComment(
 			author: comment.user?.name ?? 'unknown',
 			author_type: comment.user?.isBot ? 'bot' : 'team_member',
 			issue_id: issue.identifier,
+			issue_assignee: issue.assignee?.name ?? null,
+			issue_creator: issue.creator?.name ?? null,
 			url: comment.url,
 		},
 		payload: {

--- a/connectors/linear/src/source.ts
+++ b/connectors/linear/src/source.ts
@@ -164,6 +164,8 @@ export class LinearSource implements SourceConnector {
 							{
 								identifier: issue.identifier,
 								title: issue.title,
+								assignee: issue.assignee,
+								creator: issue.creator,
 							},
 						),
 					);


### PR DESCRIPTION
## Summary
- Adds `issue_assignee` and `issue_creator` to comment event provenance in the Linear connector
- Passes assignee/creator data from the `BatchIssueNode` through to `normalizeComment()`
- Enables filtering for "comments on tickets assigned to me" using jq transforms

Fixes #81

## Test plan
- [x] Added test: comment provenance includes `issue_assignee` and `issue_creator` when set
- [x] Added test: `issue_assignee` is `null` when issue is unassigned
- [x] All 30 Linear connector tests pass
- [x] `pnpm build`, `pnpm test`, `pnpm typecheck` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)