### PR TITLE
feat: HTTP REST API mirroring CLI interface

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -329,8 +329,19 @@ async function runForeground(configPath?: string, force?: boolean): Promise<void
 		// Start the runtime (scheduler, shared infra)
 		await runtime.start();
 
-		// Start HTTP server for control API and webhooks
+		// Start HTTP server for control API, webhooks, and REST API
 		await runtime.startHttpServer();
+
+		// Register REST API endpoints
+		const { registerRestApi } = await import('@orgloop/core');
+		registerRestApi(runtime);
+
+		// Register /api/doctor endpoint (needs CLI-level config resolution)
+		const resolvedDoctorConfigPath = resolveConfigPath(configPath);
+		runtime.getWebhookServer().registerApiHandler('doctor', async () => {
+			const { runDoctor: runDoctorCheck } = await import('./doctor.js');
+			return runDoctorCheck(resolvedDoctorConfigPath);
+		});
 
 		// Register the project loader handler so other CLI processes can add modules
 		runtime.registerControlHandler('module/load-project', async (body) => {

--- a/packages/core/src/__tests__/event-history.test.ts
+++ b/packages/core/src/__tests__/event-history.test.ts
@@ -1,0 +1,132 @@
+import type { EventRecord } from '../event-history.js';
+import { EventHistory } from '../event-history.js';
+
+function makeRecord(overrides: Partial<EventRecord> = {}): EventRecord {
+	return {
+		event_id: `evt_${Math.random().toString(36).slice(2)}`,
+		timestamp: new Date().toISOString(),
+		source: 'test-source',
+		type: 'resource.changed',
+		matched_routes: ['route-a'],
+		sop_files: [],
+		actors: ['actor-a'],
+		processing_ms: 1.5,
+		module: 'test-module',
+		...overrides,
+	};
+}
+
+describe('EventHistory', () => {
+	it('stores and retrieves events', () => {
+		const history = new EventHistory({ maxSize: 10 });
+		const record = makeRecord();
+		history.push(record);
+
+		expect(history.size()).toBe(1);
+		const results = history.query();
+		expect(results).toHaveLength(1);
+		expect(results[0].event_id).toBe(record.event_id);
+	});
+
+	it('returns events newest-first', () => {
+		const history = new EventHistory({ maxSize: 10 });
+		const r1 = makeRecord({ event_id: 'evt_1', timestamp: '2024-01-01T00:00:00Z' });
+		const r2 = makeRecord({ event_id: 'evt_2', timestamp: '2024-01-01T00:01:00Z' });
+		const r3 = makeRecord({ event_id: 'evt_3', timestamp: '2024-01-01T00:02:00Z' });
+
+		history.push(r1);
+		history.push(r2);
+		history.push(r3);
+
+		const results = history.query();
+		expect(results.map((r) => r.event_id)).toEqual(['evt_3', 'evt_2', 'evt_1']);
+	});
+
+	it('evicts oldest entries when full', () => {
+		const history = new EventHistory({ maxSize: 3 });
+		history.push(makeRecord({ event_id: 'evt_1' }));
+		history.push(makeRecord({ event_id: 'evt_2' }));
+		history.push(makeRecord({ event_id: 'evt_3' }));
+		history.push(makeRecord({ event_id: 'evt_4' }));
+
+		expect(history.size()).toBe(3);
+		const results = history.query();
+		expect(results.map((r) => r.event_id)).toEqual(['evt_4', 'evt_3', 'evt_2']);
+	});
+
+	it('filters by source', () => {
+		const history = new EventHistory({ maxSize: 10 });
+		history.push(makeRecord({ source: 'github' }));
+		history.push(makeRecord({ source: 'linear' }));
+		history.push(makeRecord({ source: 'github' }));
+
+		const results = history.query({ source: 'linear' });
+		expect(results).toHaveLength(1);
+		expect(results[0].source).toBe('linear');
+	});
+
+	it('filters by route', () => {
+		const history = new EventHistory({ maxSize: 10 });
+		history.push(makeRecord({ matched_routes: ['pr-review'] }));
+		history.push(makeRecord({ matched_routes: ['ci-failure', 'notify'] }));
+		history.push(makeRecord({ matched_routes: ['pr-review'] }));
+
+		const results = history.query({ route: 'ci-failure' });
+		expect(results).toHaveLength(1);
+		expect(results[0].matched_routes).toContain('ci-failure');
+	});
+
+	it('filters by time range', () => {
+		const history = new EventHistory({ maxSize: 10 });
+		history.push(makeRecord({ timestamp: '2024-01-01T00:00:00Z' }));
+		history.push(makeRecord({ timestamp: '2024-01-02T00:00:00Z' }));
+		history.push(makeRecord({ timestamp: '2024-01-03T00:00:00Z' }));
+
+		const results = history.query({
+			from: '2024-01-01T12:00:00Z',
+			to: '2024-01-02T12:00:00Z',
+		});
+		expect(results).toHaveLength(1);
+		expect(results[0].timestamp).toBe('2024-01-02T00:00:00Z');
+	});
+
+	it('respects limit', () => {
+		const history = new EventHistory({ maxSize: 10 });
+		for (let i = 0; i < 5; i++) {
+			history.push(makeRecord());
+		}
+
+		const results = history.query({ limit: 2 });
+		expect(results).toHaveLength(2);
+	});
+
+	it('handles empty buffer', () => {
+		const history = new EventHistory({ maxSize: 10 });
+		expect(history.size()).toBe(0);
+		expect(history.query()).toEqual([]);
+	});
+
+	it('defaults to maxSize 1000', () => {
+		const history = new EventHistory();
+		// Push 1001 records
+		for (let i = 0; i < 1001; i++) {
+			history.push(makeRecord({ event_id: `evt_${i}` }));
+		}
+		expect(history.size()).toBe(1000);
+		// Oldest (evt_0) should be evicted
+		const results = history.query();
+		expect(results[results.length - 1].event_id).toBe('evt_1');
+	});
+
+	it('combines multiple filters', () => {
+		const history = new EventHistory({ maxSize: 10 });
+		history.push(makeRecord({ source: 'github', matched_routes: ['pr-review'] }));
+		history.push(makeRecord({ source: 'github', matched_routes: ['ci-failure'] }));
+		history.push(makeRecord({ source: 'linear', matched_routes: ['pr-review'] }));
+
+		const results = history.query({ source: 'github', route: 'pr-review' });
+		expect(results).toHaveLength(1);
+		expect(results[0].source).toBe('github');
+		expect(results[0].matched_routes).toContain('pr-review');
+	});
+});

--- a/packages/core/src/__tests__/rest-api.test.ts
+++ b/packages/core/src/__tests__/rest-api.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for the REST API endpoints.
+ */
+
+import { createTestEvent, MockActor, MockSource } from '@orgloop/sdk';
+import { afterEach, describe, expect, it } from 'vitest';
+import { InMemoryBus } from '../bus.js';
+import type { ModuleConfig } from '../module-instance.js';
+import { registerRestApi } from '../rest-api.js';
+import { Runtime } from '../runtime.js';
+
+function makeModuleConfig(name: string, overrides?: Partial<ModuleConfig>): ModuleConfig {
+	return {
+		name,
+		sources: [
+			{
+				id: `${name}-source`,
+				connector: 'mock',
+				config: {},
+				poll: { interval: '5m' },
+			},
+		],
+		actors: [{ id: `${name}-actor`, connector: 'mock', config: {} }],
+		routes: [
+			{
+				name: `${name}-route`,
+				when: { source: `${name}-source`, events: ['resource.changed'] },
+				then: { actor: `${name}-actor` },
+			},
+		],
+		transforms: [],
+		loggers: [],
+		...overrides,
+	};
+}
+
+async function setupRuntime(): Promise<{
+	runtime: Runtime;
+	source: MockSource;
+	actor: MockActor;
+}> {
+	const runtime = new Runtime({
+		bus: new InMemoryBus(),
+		crashHandlers: false,
+		heartbeat: false,
+	});
+	await runtime.start();
+
+	const source = new MockSource('test-source');
+	const actor = new MockActor('test-actor');
+
+	await runtime.loadModule(makeModuleConfig('test'), {
+		sources: new Map([['test-source', source]]),
+		actors: new Map([['test-actor', actor]]),
+	});
+
+	registerRestApi(runtime);
+	return { runtime, source, actor };
+}
+
+describe('REST API', () => {
+	let runtime: Runtime;
+
+	afterEach(async () => {
+		if (runtime) {
+			try {
+				await runtime.stop();
+			} catch {
+				// already stopped
+			}
+		}
+	});
+
+	describe('GET /api/status', () => {
+		it('returns runtime status with health', async () => {
+			const setup = await setupRuntime();
+			runtime = setup.runtime;
+
+			const server = runtime.getWebhookServer();
+			const handler = (server as unknown as { apiHandlers: Map<string, unknown> }).apiHandlers.get(
+				'status',
+			) as (q: URLSearchParams) => Promise<unknown>;
+
+			const result = (await handler(new URLSearchParams())) as Record<string, unknown>;
+
+			expect(result.health).toBe('ok');
+			expect(result.running).toBe(true);
+			expect(result.pid).toBe(process.pid);
+			expect(result.uptime_ms).toBeGreaterThanOrEqual(0);
+			expect(result.modules).toHaveLength(1);
+			expect(result.sources).toHaveLength(1);
+		});
+	});
+
+	describe('GET /api/routes', () => {
+		it('returns route definitions with stats', async () => {
+			const setup = await setupRuntime();
+			runtime = setup.runtime;
+
+			const server = runtime.getWebhookServer();
+			const handler = (server as unknown as { apiHandlers: Map<string, unknown> }).apiHandlers.get(
+				'routes',
+			) as (q: URLSearchParams) => Promise<unknown>;
+
+			const result = (await handler(new URLSearchParams())) as Array<Record<string, unknown>>;
+
+			expect(result).toHaveLength(1);
+			expect(result[0].name).toBe('test-route');
+			expect(result[0].actor).toBe('test-actor');
+			expect(result[0].fire_count).toBe(0);
+			expect(result[0].last_fired).toBeNull();
+		});
+
+		it('increments fire count after event processing', async () => {
+			const setup = await setupRuntime();
+			runtime = setup.runtime;
+
+			// Inject an event that matches the route
+			const event = createTestEvent({
+				source: 'test-source',
+				type: 'resource.changed',
+			});
+			await runtime.inject(event, 'test');
+
+			const server = runtime.getWebhookServer();
+			const handler = (server as unknown as { apiHandlers: Map<string, unknown> }).apiHandlers.get(
+				'routes',
+			) as (q: URLSearchParams) => Promise<unknown>;
+
+			const result = (await handler(new URLSearchParams())) as Array<Record<string, unknown>>;
+
+			expect(result[0].fire_count).toBe(1);
+			expect(result[0].last_fired).toBeTruthy();
+		});
+	});
+
+	describe('GET /api/events', () => {
+		it('returns empty array when no events processed', async () => {
+			const setup = await setupRuntime();
+			runtime = setup.runtime;
+
+			const server = runtime.getWebhookServer();
+			const handler = (server as unknown as { apiHandlers: Map<string, unknown> }).apiHandlers.get(
+				'events',
+			) as (q: URLSearchParams) => Promise<unknown>;
+
+			const result = (await handler(new URLSearchParams())) as unknown[];
+			expect(result).toEqual([]);
+		});
+
+		it('records events after processing', async () => {
+			const setup = await setupRuntime();
+			runtime = setup.runtime;
+
+			const event = createTestEvent({
+				source: 'test-source',
+				type: 'resource.changed',
+			});
+			await runtime.inject(event, 'test');
+
+			const server = runtime.getWebhookServer();
+			const handler = (server as unknown as { apiHandlers: Map<string, unknown> }).apiHandlers.get(
+				'events',
+			) as (q: URLSearchParams) => Promise<unknown>;
+
+			const result = (await handler(new URLSearchParams())) as Array<Record<string, unknown>>;
+
+			expect(result).toHaveLength(1);
+			expect(result[0].source).toBe('test-source');
+			expect(result[0].type).toBe('resource.changed');
+			expect(result[0].matched_routes).toEqual(['test-route']);
+			expect(result[0].processing_ms).toBeGreaterThanOrEqual(0);
+		});
+
+		it('filters by source', async () => {
+			const setup = await setupRuntime();
+			runtime = setup.runtime;
+
+			const event = createTestEvent({
+				source: 'test-source',
+				type: 'resource.changed',
+			});
+			await runtime.inject(event, 'test');
+
+			const server = runtime.getWebhookServer();
+			const handler = (server as unknown as { apiHandlers: Map<string, unknown> }).apiHandlers.get(
+				'events',
+			) as (q: URLSearchParams) => Promise<unknown>;
+
+			const noMatch = (await handler(new URLSearchParams({ source: 'other-source' }))) as unknown[];
+			expect(noMatch).toEqual([]);
+
+			const match = (await handler(new URLSearchParams({ source: 'test-source' }))) as unknown[];
+			expect(match).toHaveLength(1);
+		});
+
+		it('respects limit parameter', async () => {
+			const setup = await setupRuntime();
+			runtime = setup.runtime;
+
+			for (let i = 0; i < 5; i++) {
+				const event = createTestEvent({
+					source: 'test-source',
+					type: 'resource.changed',
+				});
+				await runtime.inject(event, 'test');
+			}
+
+			const server = runtime.getWebhookServer();
+			const handler = (server as unknown as { apiHandlers: Map<string, unknown> }).apiHandlers.get(
+				'events',
+			) as (q: URLSearchParams) => Promise<unknown>;
+
+			const result = (await handler(new URLSearchParams({ limit: '2' }))) as unknown[];
+			expect(result).toHaveLength(2);
+		});
+	});
+
+	describe('GET /api/sources', () => {
+		it('returns source details', async () => {
+			const setup = await setupRuntime();
+			runtime = setup.runtime;
+
+			const server = runtime.getWebhookServer();
+			const handler = (server as unknown as { apiHandlers: Map<string, unknown> }).apiHandlers.get(
+				'sources',
+			) as (q: URLSearchParams) => Promise<unknown>;
+
+			const result = (await handler(new URLSearchParams())) as Array<Record<string, unknown>>;
+
+			expect(result).toHaveLength(1);
+			expect(result[0].id).toBe('test-source');
+			expect(result[0].connector).toBe('mock');
+			expect(result[0].type).toBe('polling');
+			expect(result[0].status).toBe('healthy');
+			expect(result[0].event_count).toBe(0);
+			expect(result[0].poll_interval).toBe('5m');
+		});
+	});
+
+	describe('GET /api/metrics', () => {
+		it('returns error message when metrics not enabled', async () => {
+			const setup = await setupRuntime();
+			runtime = setup.runtime;
+
+			const server = runtime.getWebhookServer();
+			const handler = (server as unknown as { apiHandlers: Map<string, unknown> }).apiHandlers.get(
+				'metrics',
+			) as (q: URLSearchParams) => Promise<unknown>;
+
+			const result = (await handler(new URLSearchParams())) as Record<string, unknown>;
+			expect(result.error).toContain('Metrics not enabled');
+		});
+	});
+});

--- a/packages/core/src/event-history.ts
+++ b/packages/core/src/event-history.ts
@@ -1,0 +1,120 @@
+/**
+ * EventHistory — in-memory ring buffer for recent event records.
+ *
+ * Stores processed events with routing metadata for the REST API.
+ * Configurable max size (default 1000). Oldest entries evicted on overflow.
+ */
+
+export interface EventRecord {
+	/** Event ID */
+	event_id: string;
+	/** ISO 8601 timestamp */
+	timestamp: string;
+	/** Source connector ID */
+	source: string;
+	/** Event type (resource.changed, actor.stopped, message.received) */
+	type: string;
+	/** Route(s) that matched this event */
+	matched_routes: string[];
+	/** SOP file paths for matched routes */
+	sop_files: string[];
+	/** Actor IDs delivered to */
+	actors: string[];
+	/** Processing time in milliseconds */
+	processing_ms: number;
+	/** Module that processed this event */
+	module: string;
+	/** Trace ID */
+	trace_id?: string;
+}
+
+export interface EventHistoryOptions {
+	/** Maximum number of events to retain (default: 1000) */
+	maxSize?: number;
+}
+
+export interface EventHistoryQuery {
+	/** ISO 8601 start timestamp */
+	from?: string;
+	/** ISO 8601 end timestamp */
+	to?: string;
+	/** Filter by source connector ID */
+	source?: string;
+	/** Filter by matched route name */
+	route?: string;
+	/** Maximum number of results to return */
+	limit?: number;
+}
+
+export class EventHistory {
+	private readonly buffer: EventRecord[];
+	private readonly maxSize: number;
+	private head = 0;
+	private count = 0;
+
+	constructor(options?: EventHistoryOptions) {
+		this.maxSize = options?.maxSize ?? 1000;
+		this.buffer = new Array<EventRecord>(this.maxSize);
+	}
+
+	/** Add an event record to the ring buffer. */
+	push(record: EventRecord): void {
+		this.buffer[this.head] = record;
+		this.head = (this.head + 1) % this.maxSize;
+		if (this.count < this.maxSize) {
+			this.count++;
+		}
+	}
+
+	/** Get the current number of stored records. */
+	size(): number {
+		return this.count;
+	}
+
+	/** Query events with optional filters. Returns newest-first. */
+	query(q?: EventHistoryQuery): EventRecord[] {
+		const records = this.toArray();
+
+		let filtered = records;
+
+		if (q?.from) {
+			const fromTime = new Date(q.from).getTime();
+			filtered = filtered.filter((r) => new Date(r.timestamp).getTime() >= fromTime);
+		}
+
+		if (q?.to) {
+			const toTime = new Date(q.to).getTime();
+			filtered = filtered.filter((r) => new Date(r.timestamp).getTime() <= toTime);
+		}
+
+		if (q?.source) {
+			filtered = filtered.filter((r) => r.source === q.source);
+		}
+
+		if (q?.route) {
+			const routeFilter = q.route;
+			filtered = filtered.filter((r) => r.matched_routes.includes(routeFilter));
+		}
+
+		if (q?.limit && q.limit > 0) {
+			filtered = filtered.slice(0, q.limit);
+		}
+
+		return filtered;
+	}
+
+	/** Return all records as an array, newest first. */
+	private toArray(): EventRecord[] {
+		if (this.count === 0) return [];
+
+		const result: EventRecord[] = [];
+		const start = (this.head - this.count + this.maxSize) % this.maxSize;
+
+		for (let i = this.count - 1; i >= 0; i--) {
+			const idx = (start + i) % this.maxSize;
+			result.push(this.buffer[idx]);
+		}
+
+		return result;
+	}
+}

--- a/packages/core/src/http.ts
+++ b/packages/core/src/http.ts
@@ -22,6 +22,8 @@ export interface RuntimeControl {
 	stop(): Promise<void>;
 }
 
+export type ApiHandler = (query: URLSearchParams) => Promise<unknown>;
+
 export class WebhookServer {
 	private readonly handlers: Map<string, WebhookHandler>;
 	private readonly onEvent: (event: OrgLoopEvent) => Promise<void>;
@@ -31,6 +33,7 @@ export class WebhookServer {
 		string,
 		(body: Record<string, unknown>) => Promise<unknown>
 	>();
+	private readonly apiHandlers = new Map<string, ApiHandler>();
 
 	constructor(
 		onEvent: (event: OrgLoopEvent) => Promise<void>,
@@ -46,6 +49,11 @@ export class WebhookServer {
 		handler: (body: Record<string, unknown>) => Promise<unknown>,
 	): void {
 		this.controlHandlers.set(route, handler);
+	}
+
+	/** Register a GET /api/:route handler. */
+	registerApiHandler(route: string, handler: ApiHandler): void {
+		this.apiHandlers.set(route, handler);
 	}
 
 	set runtime(rt: RuntimeControl) {
@@ -96,6 +104,12 @@ export class WebhookServer {
 		// Control API routes
 		if (parts[0] === 'control') {
 			await this.handleControlRequest(req, res, parts.slice(1));
+			return;
+		}
+
+		// REST API routes (GET /api/*)
+		if (parts[0] === 'api') {
+			await this.handleApiRequest(req, res, url, parts.slice(1));
 			return;
 		}
 
@@ -219,6 +233,46 @@ export class WebhookServer {
 
 			res.writeHead(404, { 'Content-Type': 'application/json' });
 			res.end(JSON.stringify({ error: 'Not found' }));
+		} catch (err) {
+			if (!res.headersSent) {
+				res.writeHead(500, { 'Content-Type': 'application/json' });
+				res.end(JSON.stringify({ error: err instanceof Error ? err.message : 'Internal error' }));
+			}
+		}
+	}
+
+	private async handleApiRequest(
+		req: IncomingMessage,
+		res: ServerResponse,
+		url: URL,
+		parts: string[],
+	): Promise<void> {
+		if (req.method !== 'GET') {
+			res.writeHead(405, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Method not allowed' }));
+			return;
+		}
+
+		const route = parts.join('/');
+		const handler = this.apiHandlers.get(route);
+
+		if (!handler) {
+			res.writeHead(404, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Not found' }));
+			return;
+		}
+
+		try {
+			const result = await handler(url.searchParams);
+
+			// Special case: metrics endpoint returns plain text
+			if (route === 'metrics' && typeof result === 'string') {
+				res.writeHead(200, { 'Content-Type': 'text/plain; version=0.0.4; charset=utf-8' });
+				res.end(result);
+				return;
+			}
+
+			this.jsonResponse(res, 200, result);
 		} catch (err) {
 			if (!res.headersSent) {
 				res.writeHead(500, { 'Content-Type': 'application/json' });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,7 +23,10 @@ export {
 	SchemaError,
 	TransformError,
 } from './errors.js';
-export type { RuntimeControl } from './http.js';
+export type { EventHistoryOptions, EventHistoryQuery, EventRecord } from './event-history.js';
+// Event history
+export { EventHistory } from './event-history.js';
+export type { ApiHandler, RuntimeControl } from './http.js';
 // HTTP webhook server
 export { DEFAULT_HTTP_PORT, WebhookServer } from './http.js';
 // Logger manager
@@ -38,10 +41,12 @@ export type { StripFrontMatterResult } from './prompt.js';
 // Prompt utilities
 export { stripFrontMatter } from './prompt.js';
 export { ModuleRegistry } from './registry.js';
+// REST API
+export { registerRestApi } from './rest-api.js';
 export type { MatchedRoute } from './router.js';
 // Router
 export { matchRoutes } from './router.js';
-export type { LoadModuleOptions, RuntimeOptions } from './runtime.js';
+export type { LoadModuleOptions, RouteStats, RuntimeOptions } from './runtime.js';
 // Runtime (new architecture)
 export { Runtime } from './runtime.js';
 // Scheduler

--- a/packages/core/src/metrics.ts
+++ b/packages/core/src/metrics.ts
@@ -146,4 +146,14 @@ export class MetricsServer {
 		if (addr && typeof addr === 'object') return addr.port;
 		return null;
 	}
+
+	/** Get Prometheus metrics as text (for embedding in REST API). */
+	async metricsText(): Promise<string> {
+		return this.registry.metrics();
+	}
+
+	/** Get the content type header for metrics response. */
+	contentType(): string {
+		return this.registry.contentType;
+	}
 }

--- a/packages/core/src/rest-api.ts
+++ b/packages/core/src/rest-api.ts
@@ -1,0 +1,90 @@
+/**
+ * REST API — registers /api/* endpoints on the WebhookServer.
+ *
+ * Provides structured JSON endpoints mirroring CLI functionality:
+ *   GET /api/status   — runtime health, uptime, source status, event counts
+ *   GET /api/routes   — configured routes with fire counts
+ *   GET /api/events   — recent event log with filtering
+ *   GET /api/sources  — per-source connector detail
+ *   GET /api/metrics  — Prometheus-format metrics
+ *   GET /api/doctor   — structured doctor output (registered externally)
+ */
+
+import type { Runtime } from './runtime.js';
+
+/**
+ * Register all REST API endpoints on the runtime's webhook server.
+ *
+ * The /api/doctor endpoint is NOT registered here — it requires CLI-level
+ * config resolution. Register it separately via runtime.getWebhookServer().registerApiHandler().
+ */
+export function registerRestApi(runtime: Runtime): void {
+	const server = runtime.getWebhookServer();
+
+	// GET /api/status
+	server.registerApiHandler('status', async () => {
+		const runtimeStatus = runtime.status();
+		const sources = runtime.getSourceDetails();
+
+		// Determine overall health from source statuses
+		const hasUnhealthy = sources.some((s) => s.status === 'unhealthy');
+		const hasDegraded = sources.some((s) => s.status === 'degraded');
+		let health: 'ok' | 'degraded' | 'error' = 'ok';
+		if (hasUnhealthy) health = 'error';
+		else if (hasDegraded) health = 'degraded';
+
+		return {
+			health,
+			running: runtimeStatus.running,
+			pid: runtimeStatus.pid,
+			uptime_ms: runtimeStatus.uptime_ms,
+			http_port: runtimeStatus.httpPort,
+			modules: runtimeStatus.modules.map((m) => ({
+				name: m.name,
+				state: m.state,
+				sources: m.sources,
+				routes: m.routes,
+				actors: m.actors,
+				uptime_ms: m.uptime_ms,
+			})),
+			sources: sources.map((s) => ({
+				id: s.id,
+				connector: s.connector,
+				status: s.status,
+				event_count: s.event_count,
+				last_event: s.last_event,
+			})),
+		};
+	});
+
+	// GET /api/routes
+	server.registerApiHandler('routes', async () => {
+		return runtime.getRouteDetails();
+	});
+
+	// GET /api/events?from=&to=&source=&route=&limit=
+	server.registerApiHandler('events', async (query) => {
+		const from = query.get('from') ?? undefined;
+		const to = query.get('to') ?? undefined;
+		const source = query.get('source') ?? undefined;
+		const route = query.get('route') ?? undefined;
+		const limitStr = query.get('limit');
+		const limit = limitStr ? Number.parseInt(limitStr, 10) : undefined;
+
+		return runtime.queryEvents({ from, to, source, route, limit });
+	});
+
+	// GET /api/sources
+	server.registerApiHandler('sources', async () => {
+		return runtime.getSourceDetails();
+	});
+
+	// GET /api/metrics
+	server.registerApiHandler('metrics', async () => {
+		const text = await runtime.getMetricsText();
+		if (text === null) {
+			return { error: 'Metrics not enabled. Set ORGLOOP_METRICS_PORT or metricsPort option.' };
+		}
+		return text;
+	});
+}

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -22,6 +22,8 @@ import { generateTraceId } from '@orgloop/sdk';
 import type { EventBus } from './bus.js';
 import { InMemoryBus } from './bus.js';
 import { ConnectorError, DeliveryError, ModuleNotFoundError } from './errors.js';
+import type { EventHistoryOptions, EventHistoryQuery, EventRecord } from './event-history.js';
+import { EventHistory } from './event-history.js';
 import type { RuntimeControl } from './http.js';
 import { DEFAULT_HTTP_PORT, WebhookServer } from './http.js';
 import { LoggerManager } from './logger.js';
@@ -46,6 +48,14 @@ export interface SourceCircuitBreakerOptions {
 	retryAfterMs?: number;
 }
 
+/** Per-route statistics tracked by the runtime. */
+export interface RouteStats {
+	/** Number of times this route has fired */
+	fireCount: number;
+	/** ISO 8601 timestamp of the last fire, or null if never fired */
+	lastFiredAt: string | null;
+}
+
 export interface RuntimeOptions {
 	/** Custom event bus (default: InMemoryBus) */
 	bus?: EventBus;
@@ -65,6 +75,8 @@ export interface RuntimeOptions {
 	heartbeatIntervalMs?: number;
 	/** Prometheus metrics port. Metrics only start if ORGLOOP_METRICS_PORT env is set or this is provided. */
 	metricsPort?: number;
+	/** Event history ring buffer options */
+	eventHistory?: EventHistoryOptions;
 }
 
 export interface LoadModuleOptions {
@@ -122,6 +134,10 @@ class Runtime extends EventEmitter implements RuntimeControl {
 	private readonly metricsServer: MetricsServer | null;
 	private readonly metricsPort: number | undefined;
 
+	// REST API: event history and route stats
+	private readonly eventHistory: EventHistory;
+	private readonly routeStats = new Map<string, RouteStats>();
+
 	constructor(options?: RuntimeOptions) {
 		super();
 		this.bus = options?.bus ?? new InMemoryBus();
@@ -149,6 +165,9 @@ class Runtime extends EventEmitter implements RuntimeControl {
 		} else {
 			this.metricsServer = null;
 		}
+
+		// Event history ring buffer
+		this.eventHistory = new EventHistory(options?.eventHistory);
 	}
 
 	// ─── Lifecycle ───────────────────────────────────────────────────────────
@@ -385,6 +404,7 @@ class Runtime extends EventEmitter implements RuntimeControl {
 	}
 
 	private async processEvent(event: OrgLoopEvent, mod: ModuleInstance): Promise<void> {
+		const eventStartTime = process.hrtime.bigint();
 		this.emit('event', event);
 
 		await this.emitLog('source.emit', {
@@ -408,14 +428,50 @@ class Runtime extends EventEmitter implements RuntimeControl {
 				source: event.source,
 				module: mod.name,
 			});
+
+			// Record event with no matched routes
+			const elapsedMs = Number(process.hrtime.bigint() - eventStartTime) / 1e6;
+			this.eventHistory.push({
+				event_id: event.id,
+				timestamp: event.timestamp,
+				source: event.source,
+				type: event.type,
+				matched_routes: [],
+				sop_files: [],
+				actors: [],
+				processing_ms: Math.round(elapsedMs * 100) / 100,
+				module: mod.name,
+				trace_id: event.trace_id,
+			});
+
 			await this.bus.ack(event.id);
 			return;
 		}
+
+		const matchedRouteNames: string[] = [];
+		const sopFiles: string[] = [];
+		const actorIds: string[] = [];
+		const now = new Date().toISOString();
 
 		// Process each matched route
 		for (const match of matched) {
 			const { route } = match;
 			const routeStartTime = process.hrtime.bigint();
+
+			matchedRouteNames.push(route.name);
+			actorIds.push(route.then.actor);
+			if (route.with?.prompt_file) {
+				sopFiles.push(route.with.prompt_file);
+			}
+
+			// Update route stats
+			const stats = this.routeStats.get(route.name);
+			if (stats) {
+				stats.fireCount++;
+				stats.lastFiredAt = now;
+			} else {
+				this.routeStats.set(route.name, { fireCount: 1, lastFiredAt: now });
+			}
 
 			await this.emitLog('route.match', {
 				event_id: event.id,
@@ -479,6 +535,21 @@ class Runtime extends EventEmitter implements RuntimeControl {
 				this.metricsServer.eventProcessingSeconds.observe({ route: route.name }, elapsed);
 			}
 		}
+
+		// Record event in history
+		const totalElapsedMs = Number(process.hrtime.bigint() - eventStartTime) / 1e6;
+		this.eventHistory.push({
+			event_id: event.id,
+			timestamp: event.timestamp,
+			source: event.source,
+			type: event.type,
+			matched_routes: matchedRouteNames,
+			sop_files: sopFiles,
+			actors: actorIds,
+			processing_ms: Math.round(totalElapsedMs * 100) / 100,
+			module: mod.name,
+			trace_id: event.trace_id,
+		});
 
 		// Ack the event after all routes processed
 		await this.bus.ack(event.id);
@@ -828,6 +899,115 @@ class Runtime extends EventEmitter implements RuntimeControl {
 	getModuleStatus(name: string): ModuleStatus | undefined {
 		const mod = this.registry.get(name);
 		return mod?.status();
+	}
+
+	// ─── REST API Data Access ────────────────────────────────────────────────
+
+	/** Query the event history ring buffer. */
+	queryEvents(query?: EventHistoryQuery): EventRecord[] {
+		return this.eventHistory.query(query);
+	}
+
+	/** Get route statistics (fire count, last fired). */
+	getRouteStats(): ReadonlyMap<string, RouteStats> {
+		return this.routeStats;
+	}
+
+	/** Get all route definitions across all modules with their stats. */
+	getRouteDetails(): Array<{
+		name: string;
+		module: string;
+		when: { source: string; events: string[]; filter?: Record<string, unknown> };
+		actor: string;
+		sop_file?: string;
+		fire_count: number;
+		last_fired: string | null;
+	}> {
+		const routes: Array<{
+			name: string;
+			module: string;
+			when: { source: string; events: string[]; filter?: Record<string, unknown> };
+			actor: string;
+			sop_file?: string;
+			fire_count: number;
+			last_fired: string | null;
+		}> = [];
+
+		for (const mod of this.registry.list()) {
+			for (const route of mod.getRoutes()) {
+				const stats = this.routeStats.get(route.name);
+				routes.push({
+					name: route.name,
+					module: mod.name,
+					when: {
+						source: route.when.source,
+						events: route.when.events,
+						...(route.when.filter ? { filter: route.when.filter } : {}),
+					},
+					actor: route.then.actor,
+					...(route.with?.prompt_file ? { sop_file: route.with.prompt_file } : {}),
+					fire_count: stats?.fireCount ?? 0,
+					last_fired: stats?.lastFiredAt ?? null,
+				});
+			}
+		}
+
+		return routes;
+	}
+
+	/** Get per-source detail for the REST API. */
+	getSourceDetails(): Array<{
+		id: string;
+		module: string;
+		connector: string;
+		type: 'webhook' | 'polling';
+		status: string;
+		last_event: string | null;
+		event_count: number;
+		poll_interval?: string;
+	}> {
+		const sources: Array<{
+			id: string;
+			module: string;
+			connector: string;
+			type: 'webhook' | 'polling';
+			status: string;
+			last_event: string | null;
+			event_count: number;
+			poll_interval?: string;
+		}> = [];
+
+		for (const mod of this.registry.list()) {
+			for (const srcCfg of mod.config.sources) {
+				const connector = mod.getSource(srcCfg.id);
+				const health = mod.getHealthState(srcCfg.id);
+				const isWebhook = connector && typeof connector.webhook === 'function';
+
+				sources.push({
+					id: srcCfg.id,
+					module: mod.name,
+					connector: srcCfg.connector,
+					type: isWebhook ? 'webhook' : 'polling',
+					status: health?.status ?? 'unknown',
+					last_event: health?.lastSuccessfulPoll ?? null,
+					event_count: health?.totalEventsEmitted ?? 0,
+					...(srcCfg.poll?.interval ? { poll_interval: srcCfg.poll.interval } : {}),
+				});
+			}
+		}
+
+		return sources;
+	}
+
+	/** Get the metrics registry for Prometheus text output. */
+	async getMetricsText(): Promise<string | null> {
+		if (!this.metricsServer) return null;
+		return this.metricsServer.metricsText();
+	}
+
+	/** Get the webhook server for API handler registration. */
+	getWebhookServer(): WebhookServer {
+		return this.webhookServer;
 	}
 
 	// ─── Logging ─────────────────────────────────────────────────────────────

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,8 +1,8 @@
 /**
  * @orgloop/server — OrgLoop HTTP API Server
  *
- * v1.1 scope. This package will expose the OrgLoop engine over HTTP.
- * For now it's a placeholder that re-exports the core types.
+ * Re-exports core engine and REST API registration.
  */
 
-export { OrgLoop } from '@orgloop/core';
+export type { ApiHandler, EventHistoryOptions, EventRecord, RouteStats } from '@orgloop/core';
+export { OrgLoop, registerRestApi } from '@orgloop/core';


### PR DESCRIPTION
## Summary

Adds an HTTP REST API to OrgLoop that mirrors the CLI interface, enabling the ARC dashboard and other tooling to query OrgLoop's operational data programmatically.

## Endpoints

| Endpoint | Description |
|----------|-------------|
| `GET /api/status` | Health, uptime, source connector status, event counts |
| `GET /api/routes` | Configured routes with match patterns, fire counts |
| `GET /api/events` | Recent event log with filtering (`?source=&route=&limit=`) |
| `GET /api/doctor` | Structured doctor output as JSON |
| `GET /api/sources` | Per-source connector detail |
| `GET /api/metrics` | Prometheus-format metrics |

## Implementation

- In-memory event history ring buffer (configurable, default 1000 events)
- Route fire counting and timing instrumentation
- HTTP server binds to configurable port (default 4801)
- Tests for event history and REST API

## Test Plan

- [x] Event history ring buffer tests
- [x] REST API endpoint tests
- [ ] Manual: start daemon, hit endpoints, verify JSON responses
- [ ] Manual: Arc OrgLoop adapter connects and pulls data

Closes #83