### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-03-09
+
+feat: callback-first delivery, dynamic threadId, docs audit (#94, #97, #98)
+
+
 ## [0.4.0] - 2026-02-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
   "dependencies": {
     "@orgloop/transform-agent-gate": "workspace:^"
   },
-  "version": "0.5.0"
+  "version": "0.6.0"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "OrgLoop runtime engine — library-first event routing",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "OrgLoop plugin development kit — interfaces, base classes, and test harnesses",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/server",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "OrgLoop HTTP API server",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## OrgLoop v0.6.0

### Features
- **Callback-first delivery** in OpenClaw connector (#94) — completion events route to originating session
- **Dynamic threadId** interpolation in connector-openclaw

### Fixes  
- Honor `openclaw_callback_agent_id` in delivery (#97)

### Docs
- Comprehensive audit and alignment across all documentation (#97, #98)
- SDK files, callback docs, Linear provenance fields documented

### Tests
- 1270 tests passing
- Build, typecheck, lint all green