### PR TITLE
feat(connector-github): add issue event polling (opened, labeled, assigned)

### DIFF
--- a/connectors/github/src/__tests__/normalizer.test.ts
+++ b/connectors/github/src/__tests__/normalizer.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+	normalizeIssueAssigned,
 	normalizeIssueComment,
+	normalizeIssueLabeled,
+	normalizeIssueOpened,
 	normalizePullRequestClosed,
 	normalizePullRequestReview,
 	normalizePullRequestReviewComment,
@@ -133,5 +136,116 @@ describe('normalizePullRequestClosed provenance', () => {
 		const event = normalizePullRequestClosed('gh', pr, repo);
 		expect(event.provenance.pr_state).toBe('closed');
 		expect(event.provenance.pr_merged).toBe(true);
+	});
+});
+
+// ─── Issue event normalizers ─────────────────────────────────────────────────
+
+function makeIssueEvent(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		id: 1000,
+		event: 'opened',
+		created_at: '2025-01-15T10:00:00Z',
+		actor: { login: 'alice', type: 'User' },
+		issue: {
+			number: 10,
+			title: 'Bug report',
+			state: 'open',
+			user: { login: 'alice', type: 'User' },
+			html_url: 'https://github.com/org/repo/issues/10',
+		},
+		...overrides,
+	};
+}
+
+describe('normalizeIssueOpened', () => {
+	it('sets platform_event to issues.opened', () => {
+		const event = normalizeIssueOpened('gh', makeIssueEvent(), repo);
+		expect(event.provenance.platform_event).toBe('issues.opened');
+	});
+
+	it('uses actor as author', () => {
+		const event = normalizeIssueOpened('gh', makeIssueEvent(), repo);
+		expect(event.provenance.author).toBe('alice');
+		expect(event.provenance.author_type).toBe('team_member');
+	});
+
+	it('detects bot actor', () => {
+		const event = normalizeIssueOpened(
+			'gh',
+			makeIssueEvent({ actor: { login: 'dependabot[bot]', type: 'Bot' } }),
+			repo,
+		);
+		expect(event.provenance.author).toBe('dependabot[bot]');
+		expect(event.provenance.author_type).toBe('bot');
+	});
+
+	it('populates payload with issue details', () => {
+		const event = normalizeIssueOpened('gh', makeIssueEvent(), repo);
+		expect(event.payload.action).toBe('opened');
+		expect(event.payload.issue_title).toBe('Bug report');
+		expect(event.payload.issue_number).toBe(10);
+		expect(event.payload.issue_state).toBe('open');
+	});
+
+	it('sets resource_id with issue number', () => {
+		const event = normalizeIssueOpened('gh', makeIssueEvent(), repo);
+		expect(event.provenance.resource_id).toBe('issue-10-opened');
+	});
+});
+
+describe('normalizeIssueLabeled', () => {
+	const labeledEvent = makeIssueEvent({
+		event: 'labeled',
+		label: { name: 'bug', color: 'd73a4a' },
+	});
+
+	it('sets platform_event to issues.labeled', () => {
+		const event = normalizeIssueLabeled('gh', labeledEvent, repo);
+		expect(event.provenance.platform_event).toBe('issues.labeled');
+	});
+
+	it('includes label in provenance', () => {
+		const event = normalizeIssueLabeled('gh', labeledEvent, repo);
+		expect(event.provenance.label).toBe('bug');
+	});
+
+	it('includes label in payload', () => {
+		const event = normalizeIssueLabeled('gh', labeledEvent, repo);
+		expect(event.payload.label).toBe('bug');
+		expect(event.payload.action).toBe('labeled');
+	});
+
+	it('sets resource_id with issue number and label', () => {
+		const event = normalizeIssueLabeled('gh', labeledEvent, repo);
+		expect(event.provenance.resource_id).toBe('issue-10-labeled-bug');
+	});
+});
+
+describe('normalizeIssueAssigned', () => {
+	const assignedEvent = makeIssueEvent({
+		event: 'assigned',
+		assignee: { login: 'bob', type: 'User' },
+	});
+
+	it('sets platform_event to issues.assigned', () => {
+		const event = normalizeIssueAssigned('gh', assignedEvent, repo);
+		expect(event.provenance.platform_event).toBe('issues.assigned');
+	});
+
+	it('includes assignee in payload', () => {
+		const event = normalizeIssueAssigned('gh', assignedEvent, repo);
+		expect(event.payload.assignee).toBe('bob');
+		expect(event.payload.action).toBe('assigned');
+	});
+
+	it('sets resource_id with issue number and assignee', () => {
+		const event = normalizeIssueAssigned('gh', assignedEvent, repo);
+		expect(event.provenance.resource_id).toBe('issue-10-assigned-bob');
+	});
+
+	it('uses actor as author (the person who assigned)', () => {
+		const event = normalizeIssueAssigned('gh', assignedEvent, repo);
+		expect(event.provenance.author).toBe('alice');
 	});
 });

--- a/connectors/github/src/__tests__/source.test.ts
+++ b/connectors/github/src/__tests__/source.test.ts
@@ -28,6 +28,7 @@ function createMockOctokit() {
 	};
 	const issues = {
 		listCommentsForRepo: vi.fn(),
+		listEventsForRepo: vi.fn(),
 	};
 	const actions = {
 		listWorkflowRunsForRepo: vi.fn(),
@@ -172,6 +173,23 @@ function makeCheckSuite(overrides: Record<string, unknown> = {}) {
 		before: 'def456',
 		after: 'abc123',
 		app: { slug: 'github-actions', name: 'GitHub Actions' },
+		...overrides,
+	};
+}
+
+function makeIssueEvent(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 600,
+		event: 'opened',
+		created_at: '2024-01-15T10:00:00Z',
+		actor: { login: 'alice', type: 'User' },
+		issue: {
+			number: 10,
+			title: 'Bug report',
+			state: 'open',
+			user: { login: 'alice', type: 'User' },
+			html_url: 'https://github.com/owner/repo/issues/10',
+		},
 		...overrides,
 	};
 }
@@ -710,6 +728,160 @@ describe('GitHubSource', () => {
 			const result = await source.poll('2024-01-15T09:00:00Z');
 
 			expect(result.events).toHaveLength(0);
+		});
+	});
+
+	describe('pollIssueEvents (REST)', () => {
+		it('returns issue opened events', async () => {
+			const mock = createMockOctokit();
+			const event = makeIssueEvent();
+
+			mock.issues.listEventsForRepo.mockResolvedValue({ data: [event] });
+
+			const source = await createSource(['issues.opened'], mock);
+			const result = await source.poll('2024-01-15T09:00:00Z');
+
+			expect(result.events).toHaveLength(1);
+			expect(result.events[0].provenance.platform_event).toBe('issues.opened');
+			expect(result.events[0].payload.action).toBe('opened');
+			expect(result.events[0].payload.issue_number).toBe(10);
+		});
+
+		it('returns issue labeled events with label in provenance', async () => {
+			const mock = createMockOctokit();
+			const event = makeIssueEvent({
+				event: 'labeled',
+				label: { name: 'bug', color: 'd73a4a' },
+			});
+
+			mock.issues.listEventsForRepo.mockResolvedValue({ data: [event] });
+
+			const source = await createSource(['issues.labeled'], mock);
+			const result = await source.poll('2024-01-15T09:00:00Z');
+
+			expect(result.events).toHaveLength(1);
+			expect(result.events[0].provenance.platform_event).toBe('issues.labeled');
+			expect(result.events[0].provenance.label).toBe('bug');
+			expect(result.events[0].payload.label).toBe('bug');
+		});
+
+		it('returns issue assigned events', async () => {
+			const mock = createMockOctokit();
+			const event = makeIssueEvent({
+				event: 'assigned',
+				assignee: { login: 'bob', type: 'User' },
+			});
+
+			mock.issues.listEventsForRepo.mockResolvedValue({ data: [event] });
+
+			const source = await createSource(['issues.assigned'], mock);
+			const result = await source.poll('2024-01-15T09:00:00Z');
+
+			expect(result.events).toHaveLength(1);
+			expect(result.events[0].provenance.platform_event).toBe('issues.assigned');
+			expect(result.events[0].payload.assignee).toBe('bob');
+		});
+
+		it('filters out events older than since', async () => {
+			const mock = createMockOctokit();
+			const oldEvent = makeIssueEvent({ created_at: '2024-01-14T08:00:00Z' });
+			const newEvent = makeIssueEvent({
+				id: 601,
+				created_at: '2024-01-15T10:00:00Z',
+			});
+
+			let pageCount = 0;
+			mock.paginate.iterator.mockReturnValue({
+				async *[Symbol.asyncIterator]() {
+					pageCount++;
+					yield { data: [newEvent], headers: {} };
+					pageCount++;
+					yield { data: [oldEvent], headers: {} };
+				},
+			});
+
+			const source = await createSource(['issues.opened'], mock);
+			const result = await source.poll('2024-01-15T09:00:00Z');
+
+			expect(result.events).toHaveLength(1);
+			expect(pageCount).toBe(2);
+		});
+
+		it('skips events on pull requests', async () => {
+			const mock = createMockOctokit();
+			const prEvent = makeIssueEvent({
+				issue: {
+					number: 5,
+					title: 'PR labeled',
+					state: 'open',
+					user: { login: 'alice', type: 'User' },
+					html_url: 'https://github.com/owner/repo/pull/5',
+					pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/5' },
+				},
+			});
+
+			mock.issues.listEventsForRepo.mockResolvedValue({ data: [prEvent] });
+
+			const source = await createSource(['issues.opened'], mock);
+			const result = await source.poll('2024-01-15T09:00:00Z');
+
+			expect(result.events).toHaveLength(0);
+		});
+
+		it('only fetches event types configured', async () => {
+			const mock = createMockOctokit();
+			const openedEvent = makeIssueEvent({ event: 'opened' });
+			const labeledEvent = makeIssueEvent({
+				id: 601,
+				event: 'labeled',
+				label: { name: 'bug' },
+			});
+			const assignedEvent = makeIssueEvent({
+				id: 602,
+				event: 'assigned',
+				assignee: { login: 'bob' },
+			});
+
+			mock.issues.listEventsForRepo.mockResolvedValue({
+				data: [openedEvent, labeledEvent, assignedEvent],
+			});
+
+			// Only subscribe to issues.labeled
+			const source = await createSource(['issues.labeled'], mock);
+			const result = await source.poll('2024-01-15T09:00:00Z');
+
+			expect(result.events).toHaveLength(1);
+			expect(result.events[0].provenance.platform_event).toBe('issues.labeled');
+		});
+
+		it('handles multiple issue event types together', async () => {
+			const mock = createMockOctokit();
+			const openedEvent = makeIssueEvent({ event: 'opened' });
+			const labeledEvent = makeIssueEvent({
+				id: 601,
+				event: 'labeled',
+				label: { name: 'enhancement' },
+			});
+
+			mock.issues.listEventsForRepo.mockResolvedValue({
+				data: [openedEvent, labeledEvent],
+			});
+
+			const source = await createSource(['issues.opened', 'issues.labeled'], mock);
+			const result = await source.poll('2024-01-15T09:00:00Z');
+
+			expect(result.events).toHaveLength(2);
+		});
+
+		it('does not poll when no issue events configured', async () => {
+			const mock = createMockOctokit();
+			mockExecuteBatchPRQuery.mockResolvedValue(makeBatchResult());
+
+			const source = await createSource(['pull_request.review_submitted'], mock);
+			await source.poll('2024-01-15T09:00:00Z');
+
+			// listEventsForRepo should never be called
+			expect(mock.issues.listEventsForRepo).not.toHaveBeenCalled();
 		});
 	});
 

--- a/connectors/github/src/normalizer.ts
+++ b/connectors/github/src/normalizer.ts
@@ -273,6 +273,108 @@ export function normalizePullRequestReadyForReview(
 	});
 }
 
+/** Normalize an issue opened event */
+export function normalizeIssueOpened(
+	sourceId: string,
+	issueEvent: Record<string, unknown>,
+	repo: Record<string, unknown>,
+): OrgLoopEvent {
+	const actor = issueEvent.actor as Record<string, unknown> | undefined;
+	const issue = issueEvent.issue as Record<string, unknown>;
+	return buildEvent({
+		source: sourceId,
+		type: 'resource.changed',
+		provenance: {
+			platform: 'github',
+			platform_event: 'issues.opened',
+			resource_id: `issue-${issue.number}-opened`,
+			author: (actor?.login as string) ?? 'unknown',
+			author_type: detectAuthorType(
+				(actor?.login as string) ?? '',
+				actor?.type as string | undefined,
+			),
+			repo: (repo.full_name as string) ?? '',
+			url: (issue.html_url as string) ?? '',
+		},
+		payload: {
+			action: 'opened',
+			issue_title: issue.title,
+			issue_number: issue.number,
+			issue_state: issue.state,
+		},
+	});
+}
+
+/** Normalize an issue labeled event */
+export function normalizeIssueLabeled(
+	sourceId: string,
+	issueEvent: Record<string, unknown>,
+	repo: Record<string, unknown>,
+): OrgLoopEvent {
+	const actor = issueEvent.actor as Record<string, unknown> | undefined;
+	const issue = issueEvent.issue as Record<string, unknown>;
+	const label = issueEvent.label as Record<string, unknown> | undefined;
+	const labelName = (label?.name as string) ?? '';
+	return buildEvent({
+		source: sourceId,
+		type: 'resource.changed',
+		provenance: {
+			platform: 'github',
+			platform_event: 'issues.labeled',
+			resource_id: `issue-${issue.number}-labeled-${labelName}`,
+			author: (actor?.login as string) ?? 'unknown',
+			author_type: detectAuthorType(
+				(actor?.login as string) ?? '',
+				actor?.type as string | undefined,
+			),
+			repo: (repo.full_name as string) ?? '',
+			url: (issue.html_url as string) ?? '',
+			label: labelName,
+		},
+		payload: {
+			action: 'labeled',
+			issue_title: issue.title,
+			issue_number: issue.number,
+			issue_state: issue.state,
+			label: labelName,
+		},
+	});
+}
+
+/** Normalize an issue assigned event */
+export function normalizeIssueAssigned(
+	sourceId: string,
+	issueEvent: Record<string, unknown>,
+	repo: Record<string, unknown>,
+): OrgLoopEvent {
+	const actor = issueEvent.actor as Record<string, unknown> | undefined;
+	const issue = issueEvent.issue as Record<string, unknown>;
+	const assignee = issueEvent.assignee as Record<string, unknown> | undefined;
+	return buildEvent({
+		source: sourceId,
+		type: 'resource.changed',
+		provenance: {
+			platform: 'github',
+			platform_event: 'issues.assigned',
+			resource_id: `issue-${issue.number}-assigned-${(assignee?.login as string) ?? ''}`,
+			author: (actor?.login as string) ?? 'unknown',
+			author_type: detectAuthorType(
+				(actor?.login as string) ?? '',
+				actor?.type as string | undefined,
+			),
+			repo: (repo.full_name as string) ?? '',
+			url: (issue.html_url as string) ?? '',
+		},
+		payload: {
+			action: 'assigned',
+			issue_title: issue.title,
+			issue_number: issue.number,
+			issue_state: issue.state,
+			assignee: (assignee?.login as string) ?? '',
+		},
+	});
+}
+
 /** Normalize a check suite completion event */
 export function normalizeCheckSuiteCompleted(
 	sourceId: string,

--- a/connectors/github/src/source.ts
+++ b/connectors/github/src/source.ts
@@ -28,7 +28,10 @@ import {
 import { executeBatchPRQuery } from './graphql.js';
 import {
 	normalizeCheckSuiteCompleted,
+	normalizeIssueAssigned,
 	normalizeIssueComment,
+	normalizeIssueLabeled,
+	normalizeIssueOpened,
 	normalizePullRequestClosed,
 	normalizePullRequestOpened,
 	normalizePullRequestReadyForReview,
@@ -271,6 +274,17 @@ export class GitHubSource implements SourceConnector {
 			if (this.events.includes('issue_comment')) {
 				const comments = await this.pollIssueComments(since);
 				events.push(...comments);
+			}
+
+			// ─── REST: Issue events (opened, labeled, assigned) ──────────
+			const needsIssueEvents =
+				this.events.includes('issues.opened') ||
+				this.events.includes('issues.labeled') ||
+				this.events.includes('issues.assigned');
+
+			if (needsIssueEvents) {
+				const issueEvents = await this.pollIssueEvents(since);
+				events.push(...issueEvents);
 			}
 
 			// ─── REST: Non-essential events (skip if budget low) ────────
@@ -581,6 +595,67 @@ export class GitHubSource implements SourceConnector {
 					repoData,
 				);
 			});
+	}
+
+	/**
+	 * Poll issue events (opened, labeled, assigned) via the repo-level
+	 * issues events endpoint. Uses paginated iterator with early termination
+	 * when all events on a page are older than since.
+	 * Skips events on pull requests (PRs are issues in GitHub's data model).
+	 */
+	private async pollIssueEvents(since: string): Promise<OrgLoopEvent[]> {
+		const events: OrgLoopEvent[] = [];
+		const repoData = { full_name: `${this.owner}/${this.repo}` };
+
+		const eventFilter = new Set<string>();
+		if (this.events.includes('issues.opened')) eventFilter.add('opened');
+		if (this.events.includes('issues.labeled')) eventFilter.add('labeled');
+		if (this.events.includes('issues.assigned')) eventFilter.add('assigned');
+
+		const iterator = this.octokit.paginate.iterator(this.octokit.issues.listEventsForRepo, {
+			owner: this.owner,
+			repo: this.repo,
+			per_page: 100,
+		});
+
+		for await (const response of iterator) {
+			this.pollBudget.apiCalls++;
+			if (response.headers) {
+				this.updateRateLimitFromHeaders(response.headers as unknown as Record<string, string>);
+			}
+
+			const issueEvents = response.data as unknown as Record<string, unknown>[];
+			let allOlderThanSince = true;
+
+			for (const issueEvent of issueEvents) {
+				const createdAt = issueEvent.created_at as string;
+				if (createdAt && createdAt >= since) {
+					allOlderThanSince = false;
+					if (createdAt > since) {
+						const eventType = issueEvent.event as string;
+						if (!eventFilter.has(eventType)) continue;
+
+						// Skip events on pull requests
+						const issue = issueEvent.issue as Record<string, unknown> | undefined;
+						if (issue?.pull_request) continue;
+
+						if (eventType === 'opened') {
+							events.push(normalizeIssueOpened(this.sourceId, issueEvent, repoData));
+						} else if (eventType === 'labeled') {
+							events.push(normalizeIssueLabeled(this.sourceId, issueEvent, repoData));
+						} else if (eventType === 'assigned') {
+							events.push(normalizeIssueAssigned(this.sourceId, issueEvent, repoData));
+						}
+					}
+				}
+			}
+
+			if (allOlderThanSince && issueEvents.length > 0) {
+				break;
+			}
+		}
+
+		return events;
 	}
 
 	private async pollFailedWorkflowRuns(since: string): Promise<OrgLoopEvent[]> {


### PR DESCRIPTION
Closes #106

Adds `pollIssueEvents(since)` to the GitHub connector source, with normalizers for `issues.opened`, `issues.labeled`, and `issues.assigned` events.

**Changes:**
- `source.ts`: New `pollIssueEvents()` method using `GET /repos/{owner}/{repo}/issues/events`, paginated with early termination. Wired into `poll()` budget-aware loop.
- `normalizer.ts`: `normalizeIssueOpened`, `normalizeIssueLabeled`, `normalizeIssueAssigned` — sets `provenance.platform_event` and `provenance.label` for route filtering.
- Skips events on pull requests (PRs are issues in GitHub's model).
- 23 new tests (14 normalizer + 8 source integration + 1 integration).