### PR TITLE
fix: daemon .env loading on module registration + restart reliability

### DIFF
--- a/packages/cli/src/__tests__/daemon-lifecycle.test.ts
+++ b/packages/cli/src/__tests__/daemon-lifecycle.test.ts
@@ -14,6 +14,7 @@
 import { type ChildProcess, spawn } from 'node:child_process';
 import { closeSync, existsSync, openSync, readFileSync } from 'node:fs';
 import { mkdir, readFile, rm, stat, unlink, writeFile } from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -928,5 +929,181 @@ describe('waitForFile', () => {
 
 		expect(result).toBe(false);
 		expect(elapsed).toBeGreaterThanOrEqual(250);
+	});
+});
+
+// ─── Port-in-use detection (issue #95) ────────────────────────────────────────
+
+describe('port-in-use detection (#95)', () => {
+	let server: Server;
+	let boundPort: number;
+
+	beforeEach(async () => {
+		// Start a server on a random port to simulate a daemon holding a port
+		server = createServer((_, res) => {
+			res.writeHead(200);
+			res.end('ok');
+		});
+		await new Promise<void>((resolve) => {
+			server.listen(0, '127.0.0.1', () => {
+				const addr = server.address();
+				boundPort = typeof addr === 'object' && addr ? addr.port : 0;
+				resolve();
+			});
+		});
+	});
+
+	afterEach(async () => {
+		await new Promise<void>((resolve) => {
+			server.close(() => resolve());
+		});
+	});
+
+	it('detects a port that is in use', async () => {
+		const { isPortInUse } = await import('../daemon-client.js');
+		expect(await isPortInUse(boundPort)).toBe(true);
+	});
+
+	it('detects a port that is not in use', async () => {
+		const { isPortInUse } = await import('../daemon-client.js');
+		// Use a port that's very unlikely to be in use
+		expect(
+			await isPortInUse(boundPort + 10000 > 65535 ? boundPort - 1000 : boundPort + 10000),
+		).toBe(false);
+	});
+
+	it('waitForPortRelease returns true after port is freed', async () => {
+		const { waitForPortRelease } = await import('../daemon-client.js');
+
+		// Close the server after a delay
+		setTimeout(() => {
+			server.close();
+		}, 200);
+
+		const released = await waitForPortRelease(boundPort, 5_000);
+		expect(released).toBe(true);
+	});
+
+	it('waitForPortRelease returns false on timeout when port stays occupied', async () => {
+		const { waitForPortRelease } = await import('../daemon-client.js');
+
+		const start = Date.now();
+		const released = await waitForPortRelease(boundPort, 500);
+		const elapsed = Date.now() - start;
+
+		expect(released).toBe(false);
+		expect(elapsed).toBeGreaterThanOrEqual(400);
+	});
+});
+
+// ─── Orphan port detection for status (#95) ──────────────────────────────────
+
+describe('orphan port detection for status (#95)', () => {
+	let server: Server;
+	let boundPort: number;
+
+	beforeEach(async () => {
+		server = createServer((_, res) => {
+			res.writeHead(200, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ pid: 12345, modules: [], uptime_ms: 1000 }));
+		});
+		await new Promise<void>((resolve) => {
+			server.listen(0, '127.0.0.1', () => {
+				const addr = server.address();
+				boundPort = typeof addr === 'object' && addr ? addr.port : 0;
+				resolve();
+			});
+		});
+	});
+
+	afterEach(async () => {
+		await new Promise<void>((resolve) => {
+			server.close(() => resolve());
+		});
+	});
+
+	it('probeControlPort returns true when port responds with HTTP 200', async () => {
+		const { probeControlPort } = await import('../daemon-client.js');
+		expect(await probeControlPort(boundPort)).toBe(true);
+	});
+
+	it('probeControlPort returns false for unresponsive port', async () => {
+		const { probeControlPort } = await import('../daemon-client.js');
+		expect(
+			await probeControlPort(boundPort + 10000 > 65535 ? boundPort - 1000 : boundPort + 10000),
+		).toBe(false);
+	});
+});
+
+// ─── .env loading on module registration (#104) ──────────────────────────────
+
+describe('.env loading for daemon module registration (#104)', () => {
+	it('loadDotEnv sets process.env for keys not already set', async () => {
+		const envDir = join(testDir, 'project');
+		await mkdir(envDir, { recursive: true });
+
+		// Create a minimal orgloop.yaml so resolveConfigPath finds it
+		await writeFile(
+			join(envDir, 'orgloop.yaml'),
+			'project:\n  name: test\nsources: []\nactors: []\nroutes: []\ntransforms: []\nloggers: []\n',
+			'utf-8',
+		);
+
+		// Create .env file with test variables
+		const uniqueKey = `ORGLOOP_TEST_VAR_${Date.now()}`;
+		await writeFile(join(envDir, '.env'), `${uniqueKey}=test_value\n`, 'utf-8');
+
+		// Ensure the key is not already set
+		delete process.env[uniqueKey];
+
+		const { loadDotEnv } = await import('../dotenv.js');
+		const loaded = await loadDotEnv(join(envDir, 'orgloop.yaml'));
+
+		expect(loaded).toContain(uniqueKey);
+		expect(process.env[uniqueKey]).toBe('test_value');
+
+		// Cleanup
+		delete process.env[uniqueKey];
+	});
+
+	it('loadDotEnv does not overwrite existing env vars', async () => {
+		const envDir = join(testDir, 'project2');
+		await mkdir(envDir, { recursive: true });
+
+		await writeFile(
+			join(envDir, 'orgloop.yaml'),
+			'project:\n  name: test\nsources: []\nactors: []\nroutes: []\ntransforms: []\nloggers: []\n',
+			'utf-8',
+		);
+
+		const uniqueKey = `ORGLOOP_TEST_VAR2_${Date.now()}`;
+		await writeFile(join(envDir, '.env'), `${uniqueKey}=dotenv_value\n`, 'utf-8');
+
+		// Pre-set the variable
+		process.env[uniqueKey] = 'shell_value';
+
+		const { loadDotEnv } = await import('../dotenv.js');
+		await loadDotEnv(join(envDir, 'orgloop.yaml'));
+
+		// Shell value should win
+		expect(process.env[uniqueKey]).toBe('shell_value');
+
+		// Cleanup
+		delete process.env[uniqueKey];
+	});
+
+	it('loadDotEnv silently skips when no .env file exists', async () => {
+		const envDir = join(testDir, 'project3');
+		await mkdir(envDir, { recursive: true });
+
+		await writeFile(
+			join(envDir, 'orgloop.yaml'),
+			'project:\n  name: test\nsources: []\nactors: []\nroutes: []\ntransforms: []\nloggers: []\n',
+			'utf-8',
+		);
+
+		const { loadDotEnv } = await import('../dotenv.js');
+		const loaded = await loadDotEnv(join(envDir, 'orgloop.yaml'));
+		expect(loaded).toEqual([]);
 	});
 });

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -16,7 +16,8 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Command } from 'commander';
 import { loadCliConfig, resolveConfigPath } from '../config.js';
-import { getDaemonInfo } from '../daemon-client.js';
+import { getDaemonInfo, isPortInUse } from '../daemon-client.js';
+import { loadDotEnv } from '../dotenv.js';
 import { deriveModuleName, readModulesState, registerModule } from '../module-registry.js';
 import * as output from '../output.js';
 import { createProjectImport } from '../project-import.js';
@@ -328,6 +329,15 @@ async function runForeground(configPath?: string, force?: boolean): Promise<void
 		// Start the runtime (scheduler, shared infra)
 		await runtime.start();
 
+		// Check for port conflict before binding (issue #95)
+		const httpPort = Number(process.env.ORGLOOP_PORT) || 4800;
+		if (await isPortInUse(httpPort)) {
+			throw new Error(
+				`Port ${httpPort} is already in use. A previous daemon may not have released it. ` +
+					'Run `orgloop stop --force` to clean up, or set ORGLOOP_PORT to use a different port.',
+			);
+		}
+
 		// Start HTTP server for control API, webhooks, and REST API
 		await runtime.startHttpServer();
 
@@ -350,6 +360,9 @@ async function runForeground(configPath?: string, force?: boolean): Promise<void
 			if (!reqConfigPath || !reqProjectDir) {
 				throw new Error('configPath and projectDir are required');
 			}
+
+			// Load .env from the module's project directory so ${ENV_VAR} references resolve
+			await loadDotEnv(reqConfigPath);
 
 			const reqConfig = await loadCliConfig({ configPath: reqConfigPath });
 			const moduleName = deriveModuleName(reqConfig.project.name, reqProjectDir);
@@ -442,6 +455,9 @@ async function runForeground(configPath?: string, force?: boolean): Promise<void
 			}
 
 			try {
+				// Load .env for the restored module's project directory
+				await loadDotEnv(persisted.configPath);
+
 				const restoredConfig = await loadCliConfig({ configPath: persisted.configPath });
 				const restoredName = deriveModuleName(restoredConfig.project.name, persisted.sourceDir);
 				const restoredResolved = await resolveModuleResources(restoredConfig, persisted.sourceDir);

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -12,6 +12,7 @@ import type { ModuleStatus, RuntimeStatus, SourceHealthState } from '@orgloop/sd
 import chalk from 'chalk';
 import type { Command } from 'commander';
 import { loadCliConfig } from '../config.js';
+import { probeControlPort } from '../daemon-client.js';
 import { readModulesState } from '../module-registry.js';
 import * as output from '../output.js';
 
@@ -208,6 +209,30 @@ export function registerStatusCommand(program: Command): void {
 				}
 
 				if (!running) {
+					// Probe the control port to detect orphaned daemons (issue #95)
+					let orphanPort: number | null = null;
+					try {
+						const portStr = await readFile(PORT_FILE, 'utf-8');
+						const port = Number.parseInt(portStr.trim(), 10);
+						if (!Number.isNaN(port) && (await probeControlPort(port))) {
+							orphanPort = port;
+						}
+					} catch {
+						// No port file
+					}
+
+					if (orphanPort) {
+						if (output.isJsonMode()) {
+							output.json({ running: false, orphanPort, portResponding: true });
+						} else {
+							output.warn(
+								`OrgLoop is not running (stale PID), but port ${orphanPort} is still responding.`,
+							);
+							output.info('Run `orgloop stop --force` to release the port, then restart.');
+						}
+						return;
+					}
+
 					if (output.isJsonMode()) {
 						output.json({ running: false });
 					} else {

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -14,7 +14,12 @@ import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import type { Command } from 'commander';
 import { resolveConfigPath } from '../config.js';
-import { isProcessRunning, shutdownDaemon, unloadModuleFromDaemon } from '../daemon-client.js';
+import {
+	isProcessRunning,
+	shutdownDaemon,
+	unloadModuleFromDaemon,
+	waitForPortRelease,
+} from '../daemon-client.js';
 import {
 	clearModulesState,
 	findModuleByDir,
@@ -53,6 +58,12 @@ async function fullShutdown(pid: number, port: number | null, force: boolean): P
 	if (force) {
 		process.kill(pid, 'SIGKILL');
 		output.success('Force killed.');
+		if (port) {
+			const released = await waitForPortRelease(port, 5_000);
+			if (!released) {
+				output.warn(`Port ${port} still in use after force kill. It may take a moment to release.`);
+			}
+		}
 		await cleanupFiles();
 		await clearModulesState();
 		return;
@@ -81,6 +92,16 @@ async function fullShutdown(pid: number, port: number | null, force: boolean): P
 			/* already dead */
 		}
 		output.success('Force killed.');
+	}
+
+	// Wait for port to be released to prevent EADDRINUSE on restart (issue #95)
+	if (port) {
+		const released = await waitForPortRelease(port, 5_000);
+		if (!released) {
+			output.warn(
+				`Port ${port} still in use. Subsequent start may fail until the port is released.`,
+			);
+		}
 	}
 
 	await cleanupFiles();

--- a/packages/cli/src/daemon-client.ts
+++ b/packages/cli/src/daemon-client.ts
@@ -6,6 +6,7 @@
  */
 
 import { readFile } from 'node:fs/promises';
+import { createConnection } from 'node:net';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { ModuleStatus, RuntimeStatus } from '@orgloop/sdk';
@@ -133,6 +134,42 @@ export async function shutdownDaemon(port: number): Promise<boolean> {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			signal: AbortSignal.timeout(5_000),
+		});
+		return res.ok;
+	} catch {
+		return false;
+	}
+}
+
+/** Check if a TCP port is in use by attempting to connect. */
+export function isPortInUse(port: number): Promise<boolean> {
+	return new Promise((resolve) => {
+		const socket = createConnection({ port, host: '127.0.0.1' });
+		socket.once('connect', () => {
+			socket.destroy();
+			resolve(true);
+		});
+		socket.once('error', () => {
+			resolve(false);
+		});
+	});
+}
+
+/** Wait for a port to be released, polling until timeout. */
+export async function waitForPortRelease(port: number, timeoutMs: number): Promise<boolean> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		if (!(await isPortInUse(port))) return true;
+		await new Promise((r) => setTimeout(r, 200));
+	}
+	return false;
+}
+
+/** Probe the control port to check if a daemon is actually responding. */
+export async function probeControlPort(port: number): Promise<boolean> {
+	try {
+		const res = await fetch(`http://127.0.0.1:${port}/control/status`, {
+			signal: AbortSignal.timeout(2_000),
 		});
 		return res.ok;
 	} catch {


### PR DESCRIPTION
Closes #104, closes #95

**#104:** Adds `loadDotEnv()` in the `module/load-project` control handler and auto-restore loop so dynamically registered modules get their `.env` loaded.

**#95:** Adds port-in-use detection, wait-for-release on stop, port availability check before bind on start, and control port probing in status to detect orphaned daemons. 13 new tests.