### PR TITLE
feat(connector-github): webhook-based connector for real-time event delivery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,8 +74,9 @@ packages/
 
 connectors/
   coding-agent/ — Hook-based: harness-agnostic webhook receiver for any coding agent
-  github/       — Poll-based: PR reviews, comments, CI failures, bot detection
-  linear/       — Poll-based: GraphQL, state change detection, comments
+  github/         — Poll-based: PR reviews, comments, CI failures, bot detection
+  github-webhook/ — Webhook-based: real-time GitHub event delivery, reuses github normalizers
+  linear/         — Poll-based: GraphQL, state change detection, comments
   claude-code/  — Backward-compat alias for coding-agent (delegates to coding-agent)
   openclaw/     — Target: POST delivery to OpenClaw agent webhooks
   webhook/      — Generic: source (HMAC validation) + target (configurable HTTP)
@@ -178,6 +179,7 @@ Every plugin type (connector, transform, logger) must be wired through the **ful
 | Config loading + env var substitution | `packages/cli/src/__tests__/config-loading.test.ts` | 7 |
 | Connector resolution | `packages/cli/src/__tests__/resolve-connectors.test.ts` | 7 |
 | Connector config field compatibility | `packages/cli/src/__tests__/connector-config-compat.test.ts` | 40 |
+| GitHub webhook (signature, normalization, filtering) | `connectors/github-webhook/src/__tests__/source.test.ts` | 31 |
 | Coding agent (harness-agnostic) lifecycle | `connectors/coding-agent/src/__tests__/source.test.ts` | 30 |
 | Claude Code backward compat | `connectors/claude-code/src/__tests__/source.test.ts` | 4 |
 | Codex lifecycle conformance | `connectors/codex/src/__tests__/source.test.ts` | 26 |

--- a/connectors/github-webhook/README.md
+++ b/connectors/github-webhook/README.md
@@ -1,0 +1,106 @@
+# @orgloop/connector-github-webhook
+
+Receives GitHub webhook POST deliveries for real-time event processing. Uses the same normalizer functions as the polling `@orgloop/connector-github` to produce identical OrgLoop events — but with zero latency instead of polling intervals.
+
+## Install
+
+```bash
+npm install @orgloop/connector-github-webhook
+```
+
+## Configuration
+
+```yaml
+sources:
+  - id: github-webhook
+    connector: "@orgloop/connector-github-webhook"
+    config:
+      secret: "${GITHUB_WEBHOOK_SECRET}"   # HMAC-SHA256 secret (must match GitHub config)
+      path: /webhook/github                # optional — defaults to source ID
+      events:                              # optional — filter which events to process
+        - pull_request.opened
+        - pull_request.closed
+        - pull_request.merged
+        - pull_request.ready_for_review
+        - pull_request.review_submitted
+        - pull_request_review_comment
+        - issue_comment
+        - workflow_run.completed
+        - check_suite.completed
+      buffer_dir: /tmp/orgloop-buffers     # optional — persist events across restarts
+    poll:
+      interval: "30s"                      # drain interval for buffered webhook events
+```
+
+### Config options
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `secret` | `string` | recommended | HMAC-SHA256 secret for signature validation. Supports `${ENV_VAR}` syntax |
+| `path` | `string` | no | URL path for the webhook handler (default: derived from source ID) |
+| `events` | `string[]` | no | Event types to accept (accepts all if omitted) |
+| `buffer_dir` | `string` | no | Directory for persisting buffered events across restarts |
+
+## Events emitted
+
+All events are emitted as OrgLoop `resource.changed` type. Produces identical event payloads and provenance to `@orgloop/connector-github`.
+
+### Supported event types
+
+| OrgLoop event string | GitHub webhook event | OrgLoop type |
+|---|---|---|
+| `pull_request.review_submitted` | `pull_request_review` (submitted) | `resource.changed` |
+| `pull_request_review_comment` | `pull_request_review_comment` | `resource.changed` |
+| `issue_comment` | `issue_comment` | `resource.changed` |
+| `pull_request.opened` | `pull_request` (opened) | `resource.changed` |
+| `pull_request.closed` | `pull_request` (closed, not merged) | `resource.changed` |
+| `pull_request.merged` | `pull_request` (closed, merged) | `resource.changed` |
+| `pull_request.ready_for_review` | `pull_request` (ready_for_review) | `resource.changed` |
+| `workflow_run.completed` | `workflow_run` (completed) | `resource.changed` |
+| `check_suite.completed` | `check_suite` (completed) | `resource.changed` |
+
+Unknown GitHub event types are emitted as raw `resource.changed` events with the full webhook payload.
+
+## Coexistence with polling connector
+
+Use both connectors for real-time delivery with polling as a fallback:
+
+```yaml
+sources:
+  - id: github-webhook
+    connector: "@orgloop/connector-github-webhook"
+    config:
+      secret: "${GITHUB_WEBHOOK_SECRET}"
+    poll:
+      interval: "30s"
+
+  - id: github-poll
+    connector: "@orgloop/connector-github"
+    config:
+      repo: "my-org/my-repo"
+      token: "${GITHUB_TOKEN}"
+      events:
+        - pull_request.review_submitted
+        - issue_comment
+    poll:
+      interval: "5m"
+```
+
+Use a dedup transform to avoid processing the same event twice.
+
+## GitHub webhook setup
+
+1. Go to your repository's **Settings → Webhooks → Add webhook**
+2. Set **Payload URL** to your OrgLoop endpoint (e.g., `https://your-host:4800/webhook/github-webhook`)
+3. Set **Content type** to `application/json`
+4. Set **Secret** to your `GITHUB_WEBHOOK_SECRET` value
+5. Select the events you want to receive (or choose "Send me everything")
+
+## Signature validation
+
+When `secret` is configured, the connector validates every incoming request using the `X-Hub-Signature-256` header (HMAC-SHA256). Requests with missing or invalid signatures are rejected with HTTP 401.
+
+## Limitations
+
+- **Requires inbound network access** — the OrgLoop HTTP server must be reachable from GitHub. For local development, use a tunnel service (ngrok, cloudflared, etc.).
+- **No replay** — missed webhook deliveries while the server is down are not recovered. Pair with the polling connector for durability.

--- a/connectors/github-webhook/package.json
+++ b/connectors/github-webhook/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@orgloop/connector-github-webhook",
+  "version": "0.1.0",
+  "description": "OrgLoop GitHub webhook connector — real-time event delivery via GitHub webhooks",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@orgloop/sdk": "workspace:*",
+    "@orgloop/connector-github": "workspace:*"
+  },
+  "orgloop": {
+    "type": "connector",
+    "provides": [
+      "source"
+    ],
+    "id": "github-webhook"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT"
+}

--- a/connectors/github-webhook/src/__tests__/source.test.ts
+++ b/connectors/github-webhook/src/__tests__/source.test.ts
@@ -1,0 +1,871 @@
+import { createHmac } from 'node:crypto';
+import { EventEmitter } from 'node:events';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { GitHubWebhookSource } from '../source.js';
+
+const TEST_SECRET = 'test-github-webhook-secret';
+
+function createMockRequest(
+	body: string,
+	method = 'POST',
+	headers: Record<string, string> = {},
+): IncomingMessage {
+	const req = new EventEmitter() as unknown as IncomingMessage;
+	req.method = method;
+	req.headers = { ...headers };
+	setTimeout(() => {
+		(req as EventEmitter).emit('data', Buffer.from(body));
+		(req as EventEmitter).emit('end');
+	}, 0);
+	return req;
+}
+
+function createMockResponse(): ServerResponse & { statusCode: number; body: string } {
+	const res = {
+		statusCode: 200,
+		body: '',
+		writeHead(code: number, _headers?: Record<string, string>) {
+			res.statusCode = code;
+			return res;
+		},
+		end(data?: string) {
+			res.body = data ?? '';
+			return res;
+		},
+	} as unknown as ServerResponse & { statusCode: number; body: string };
+	return res;
+}
+
+function signPayload(body: string, secret: string): string {
+	return `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
+}
+
+// ─── Sample GitHub webhook payloads ──────────────────────────────────────────
+
+const sampleRepo = {
+	full_name: 'org/repo',
+	name: 'repo',
+};
+
+const samplePR = {
+	number: 42,
+	title: 'Add feature X',
+	state: 'open',
+	draft: false,
+	merged: false,
+	merged_at: null,
+	html_url: 'https://github.com/org/repo/pull/42',
+	user: { login: 'alice', type: 'User' },
+	head: { ref: 'feat/x' },
+	base: { ref: 'main' },
+};
+
+const sampleReview = {
+	id: 101,
+	state: 'changes_requested',
+	body: 'Please fix the tests',
+	html_url: 'https://github.com/org/repo/pull/42#pullrequestreview-101',
+	user: { login: 'bob', type: 'User' },
+};
+
+const sampleComment = {
+	id: 201,
+	body: 'This looks good',
+	html_url: 'https://github.com/org/repo/pull/42#issuecomment-201',
+	diff_hunk: '@@ -1,5 +1,7 @@',
+	path: 'src/index.ts',
+	user: { login: 'carol', type: 'User' },
+};
+
+const sampleIssueComment = {
+	id: 301,
+	body: 'I agree with the approach',
+	html_url: 'https://github.com/org/repo/issues/10#issuecomment-301',
+	user: { login: 'dave', type: 'User' },
+};
+
+const sampleIssue = {
+	number: 10,
+	title: 'Bug: widgets broken',
+	state: 'open',
+	user: { login: 'eve', type: 'User' },
+	pull_request: undefined,
+};
+
+const sampleWorkflowRun = {
+	id: 501,
+	name: 'CI',
+	run_number: 99,
+	conclusion: 'failure',
+	head_branch: 'main',
+	head_sha: 'abc123',
+	html_url: 'https://github.com/org/repo/actions/runs/501',
+	actor: { login: 'github-actions[bot]', type: 'Bot' },
+};
+
+const sampleCheckSuite = {
+	id: 601,
+	conclusion: 'success',
+	status: 'completed',
+	head_branch: 'main',
+	head_sha: 'abc123',
+	url: 'https://api.github.com/repos/org/repo/check-suites/601',
+	app: { name: 'GitHub Actions', slug: 'github-actions' },
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('GitHubWebhookSource', () => {
+	let source: GitHubWebhookSource;
+
+	beforeEach(async () => {
+		source = new GitHubWebhookSource();
+	});
+
+	afterEach(async () => {
+		await source.shutdown();
+	});
+
+	// ─── Initialization ──────────────────────────────────────────────────────
+
+	it('initializes without error', async () => {
+		await source.init({
+			id: 'gh-webhook',
+			connector: '@orgloop/connector-github-webhook',
+			config: {},
+		});
+		expect(source.id).toBe('github-webhook');
+	});
+
+	it('returns empty events on initial poll', async () => {
+		await source.init({
+			id: 'gh-webhook',
+			connector: '@orgloop/connector-github-webhook',
+			config: {},
+		});
+		const result = await source.poll(null);
+		expect(result.events).toHaveLength(0);
+		expect(result.checkpoint).toBeDefined();
+	});
+
+	// ─── Signature validation ────────────────────────────────────────────────
+
+	describe('HMAC signature validation', () => {
+		beforeEach(async () => {
+			process.env.TEST_GH_WEBHOOK_SECRET = TEST_SECRET;
+			await source.init({
+				id: 'gh-webhook',
+				connector: '@orgloop/connector-github-webhook',
+				config: { secret: '${TEST_GH_WEBHOOK_SECRET}' },
+			});
+		});
+
+		afterEach(() => {
+			delete process.env.TEST_GH_WEBHOOK_SECRET;
+		});
+
+		it('accepts valid signature', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'opened',
+				pull_request: samplePR,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'pull_request',
+				'x-hub-signature-256': signPayload(body, TEST_SECRET),
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(res.statusCode).toBe(200);
+			expect(events).toHaveLength(1);
+		});
+
+		it('rejects missing signature', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'opened',
+				pull_request: samplePR,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'pull_request',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(res.statusCode).toBe(401);
+			expect(events).toHaveLength(0);
+			expect(JSON.parse(res.body).error).toContain('Missing');
+		});
+
+		it('rejects invalid signature', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'opened',
+				pull_request: samplePR,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'pull_request',
+				'x-hub-signature-256': 'sha256=deadbeef',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(res.statusCode).toBe(401);
+			expect(events).toHaveLength(0);
+			expect(JSON.parse(res.body).error).toContain('Invalid signature');
+		});
+	});
+
+	// ─── Request validation ──────────────────────────────────────────────────
+
+	describe('request validation', () => {
+		beforeEach(async () => {
+			await source.init({
+				id: 'gh-webhook',
+				connector: '@orgloop/connector-github-webhook',
+				config: {},
+			});
+		});
+
+		it('rejects non-POST requests', async () => {
+			const handler = source.webhook();
+			const req = createMockRequest('', 'GET', { 'x-github-event': 'ping' });
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(res.statusCode).toBe(405);
+			expect(events).toHaveLength(0);
+		});
+
+		it('rejects requests without X-GitHub-Event header', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({ action: 'opened' });
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			await handler(req, res);
+			expect(res.statusCode).toBe(400);
+			expect(JSON.parse(res.body).error).toContain('X-GitHub-Event');
+		});
+
+		it('rejects invalid JSON', async () => {
+			const handler = source.webhook();
+			const req = createMockRequest('not-json', 'POST', {
+				'x-github-event': 'pull_request',
+			});
+			const res = createMockResponse();
+
+			await handler(req, res);
+			expect(res.statusCode).toBe(400);
+			expect(JSON.parse(res.body).error).toContain('Invalid JSON');
+		});
+	});
+
+	// ─── Pull request events ─────────────────────────────────────────────────
+
+	describe('pull_request events', () => {
+		beforeEach(async () => {
+			await source.init({
+				id: 'gh-webhook',
+				connector: '@orgloop/connector-github-webhook',
+				config: {},
+			});
+		});
+
+		it('normalizes pull_request.opened', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'opened',
+				pull_request: samplePR,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'pull_request',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(res.statusCode).toBe(200);
+			expect(events).toHaveLength(1);
+			expect(events[0].type).toBe('resource.changed');
+			expect(events[0].provenance.platform).toBe('github');
+			expect(events[0].provenance.platform_event).toBe('pull_request.opened');
+			expect(events[0].payload.action).toBe('opened');
+			expect(events[0].payload.pr_number).toBe(42);
+			expect(events[0].payload.pr_title).toBe('Add feature X');
+		});
+
+		it('normalizes pull_request.closed (not merged)', async () => {
+			const handler = source.webhook();
+			const closedPR = { ...samplePR, state: 'closed', merged: false };
+			const body = JSON.stringify({
+				action: 'closed',
+				pull_request: closedPR,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'pull_request',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform_event).toBe('pull_request.closed');
+			expect(events[0].payload.action).toBe('closed');
+			expect(events[0].payload.merged).toBe(false);
+		});
+
+		it('normalizes pull_request.closed (merged)', async () => {
+			const handler = source.webhook();
+			const mergedPR = {
+				...samplePR,
+				state: 'closed',
+				merged: true,
+				merged_at: '2024-01-15T10:00:00Z',
+				merged_by: { login: 'alice' },
+			};
+			const body = JSON.stringify({
+				action: 'closed',
+				pull_request: mergedPR,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'pull_request',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform_event).toBe('pull_request.merged');
+			expect(events[0].payload.action).toBe('merged');
+			expect(events[0].payload.merged).toBe(true);
+			expect(events[0].payload.merged_by).toBe('alice');
+		});
+
+		it('normalizes pull_request.ready_for_review', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'ready_for_review',
+				pull_request: { ...samplePR, draft: false },
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'pull_request',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform_event).toBe('pull_request.ready_for_review');
+			expect(events[0].payload.action).toBe('ready_for_review');
+		});
+
+		it('handles unknown pull_request actions as raw events', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'labeled',
+				pull_request: samplePR,
+				repository: sampleRepo,
+				label: { name: 'bug' },
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'pull_request',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform_event).toBe('pull_request.labeled');
+			expect(events[0].payload.action).toBe('labeled');
+		});
+	});
+
+	// ─── Review events ───────────────────────────────────────────────────────
+
+	describe('pull_request_review events', () => {
+		beforeEach(async () => {
+			await source.init({
+				id: 'gh-webhook',
+				connector: '@orgloop/connector-github-webhook',
+				config: {},
+			});
+		});
+
+		it('normalizes pull_request_review.submitted', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'submitted',
+				review: sampleReview,
+				pull_request: samplePR,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'pull_request_review',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform_event).toBe('pull_request.review_submitted');
+			expect(events[0].payload.review_state).toBe('changes_requested');
+			expect(events[0].payload.review_body).toBe('Please fix the tests');
+			expect(events[0].provenance.author).toBe('bob');
+		});
+	});
+
+	// ─── Review comment events ───────────────────────────────────────────────
+
+	describe('pull_request_review_comment events', () => {
+		beforeEach(async () => {
+			await source.init({
+				id: 'gh-webhook',
+				connector: '@orgloop/connector-github-webhook',
+				config: {},
+			});
+		});
+
+		it('normalizes review comment', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'created',
+				comment: sampleComment,
+				pull_request: samplePR,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'pull_request_review_comment',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform_event).toBe('pull_request_review_comment');
+			expect(events[0].payload.comment_body).toBe('This looks good');
+			expect(events[0].payload.path).toBe('src/index.ts');
+		});
+	});
+
+	// ─── Issue comment events ────────────────────────────────────────────────
+
+	describe('issue_comment events', () => {
+		beforeEach(async () => {
+			await source.init({
+				id: 'gh-webhook',
+				connector: '@orgloop/connector-github-webhook',
+				config: {},
+			});
+		});
+
+		it('normalizes issue comment', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'created',
+				comment: sampleIssueComment,
+				issue: sampleIssue,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'issue_comment',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform_event).toBe('issue_comment');
+			expect(events[0].payload.comment_body).toBe('I agree with the approach');
+			expect(events[0].payload.issue_number).toBe(10);
+		});
+	});
+
+	// ─── Workflow run events ─────────────────────────────────────────────────
+
+	describe('workflow_run events', () => {
+		beforeEach(async () => {
+			await source.init({
+				id: 'gh-webhook',
+				connector: '@orgloop/connector-github-webhook',
+				config: {},
+			});
+		});
+
+		it('normalizes failed workflow run', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'completed',
+				workflow_run: sampleWorkflowRun,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'workflow_run',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform_event).toBe('workflow_run.completed');
+			expect(events[0].payload.action).toBe('workflow_run_failed');
+			expect(events[0].payload.conclusion).toBe('failure');
+		});
+
+		it('emits raw event for non-failure workflow runs', async () => {
+			const handler = source.webhook();
+			const successRun = { ...sampleWorkflowRun, conclusion: 'success' };
+			const body = JSON.stringify({
+				action: 'completed',
+				workflow_run: successRun,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'workflow_run',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform_event).toBe('workflow_run.completed');
+		});
+
+		it('ignores non-completed workflow actions', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'requested',
+				workflow_run: sampleWorkflowRun,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'workflow_run',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(0);
+		});
+	});
+
+	// ─── Check suite events ──────────────────────────────────────────────────
+
+	describe('check_suite events', () => {
+		beforeEach(async () => {
+			await source.init({
+				id: 'gh-webhook',
+				connector: '@orgloop/connector-github-webhook',
+				config: {},
+			});
+		});
+
+		it('normalizes completed check suite', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'completed',
+				check_suite: sampleCheckSuite,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'check_suite',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform_event).toBe('check_suite.completed');
+			expect(events[0].payload.conclusion).toBe('success');
+			expect(events[0].payload.app_name).toBe('GitHub Actions');
+		});
+
+		it('ignores non-completed check suite actions', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'requested',
+				check_suite: sampleCheckSuite,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'check_suite',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(0);
+		});
+	});
+
+	// ─── Event filtering ─────────────────────────────────────────────────────
+
+	describe('event filtering', () => {
+		it('only accepts configured event types', async () => {
+			await source.init({
+				id: 'gh-webhook',
+				connector: '@orgloop/connector-github-webhook',
+				config: { events: ['pull_request.opened'] },
+			});
+
+			const handler = source.webhook();
+
+			// Allowed: pull_request opened
+			const body1 = JSON.stringify({
+				action: 'opened',
+				pull_request: samplePR,
+				repository: sampleRepo,
+			});
+			const req1 = createMockRequest(body1, 'POST', {
+				'x-github-event': 'pull_request',
+			});
+			const res1 = createMockResponse();
+			const events1 = await handler(req1, res1);
+			expect(events1).toHaveLength(1);
+
+			// Blocked: issue_comment
+			const body2 = JSON.stringify({
+				action: 'created',
+				comment: sampleIssueComment,
+				issue: sampleIssue,
+				repository: sampleRepo,
+			});
+			const req2 = createMockRequest(body2, 'POST', {
+				'x-github-event': 'issue_comment',
+			});
+			const res2 = createMockResponse();
+			const events2 = await handler(req2, res2);
+			expect(events2).toHaveLength(0);
+		});
+
+		it('accepts all events when no filter is configured', async () => {
+			await source.init({
+				id: 'gh-webhook',
+				connector: '@orgloop/connector-github-webhook',
+				config: {},
+			});
+
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'created',
+				comment: sampleIssueComment,
+				issue: sampleIssue,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'issue_comment',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+		});
+	});
+
+	// ─── Unknown event types ─────────────────────────────────────────────────
+
+	describe('unknown event types', () => {
+		beforeEach(async () => {
+			await source.init({
+				id: 'gh-webhook',
+				connector: '@orgloop/connector-github-webhook',
+				config: {},
+			});
+		});
+
+		it('emits raw events for unknown GitHub event types', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'created',
+				release: { tag_name: 'v1.0.0' },
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'release',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform).toBe('github');
+			expect(events[0].provenance.platform_event).toBe('release.created');
+			expect(events[0].type).toBe('resource.changed');
+		});
+	});
+
+	// ─── Poll draining ───────────────────────────────────────────────────────
+
+	describe('poll drains webhook buffer', () => {
+		beforeEach(async () => {
+			await source.init({
+				id: 'gh-webhook',
+				connector: '@orgloop/connector-github-webhook',
+				config: {},
+			});
+		});
+
+		it('poll returns events received via webhook', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'opened',
+				pull_request: samplePR,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'pull_request',
+			});
+			const res = createMockResponse();
+
+			await handler(req, res);
+
+			const result = await source.poll(null);
+			expect(result.events).toHaveLength(1);
+			expect(result.events[0].provenance.platform_event).toBe('pull_request.opened');
+
+			// Second poll returns empty
+			const result2 = await source.poll(result.checkpoint);
+			expect(result2.events).toHaveLength(0);
+		});
+	});
+
+	// ─── Buffer persistence ──────────────────────────────────────────────────
+
+	describe('buffer persistence', () => {
+		let bufferDir: string;
+
+		beforeEach(() => {
+			bufferDir = join(tmpdir(), `orgloop-gh-webhook-test-${Date.now()}`);
+			mkdirSync(bufferDir, { recursive: true });
+		});
+
+		afterEach(() => {
+			if (existsSync(bufferDir)) {
+				rmSync(bufferDir, { recursive: true });
+			}
+		});
+
+		it('persists events to disk when buffer_dir is set', async () => {
+			await source.init({
+				id: 'gh-webhook',
+				connector: '@orgloop/connector-github-webhook',
+				config: { buffer_dir: bufferDir },
+			});
+
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'opened',
+				pull_request: samplePR,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'pull_request',
+			});
+			const res = createMockResponse();
+
+			await handler(req, res);
+
+			// Create a new source instance to verify persistence
+			const source2 = new GitHubWebhookSource();
+			await source2.init({
+				id: 'gh-webhook',
+				connector: '@orgloop/connector-github-webhook',
+				config: { buffer_dir: bufferDir },
+			});
+
+			const result = await source2.poll(null);
+			expect(result.events).toHaveLength(1);
+			expect(result.events[0].provenance.platform_event).toBe('pull_request.opened');
+			await source2.shutdown();
+		});
+	});
+
+	// ─── Event ID and structure ──────────────────────────────────────────────
+
+	describe('event structure', () => {
+		beforeEach(async () => {
+			await source.init({
+				id: 'gh-webhook',
+				connector: '@orgloop/connector-github-webhook',
+				config: {},
+			});
+		});
+
+		it('produces well-formed OrgLoop events', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'opened',
+				pull_request: samplePR,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'pull_request',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			const event = events[0];
+			expect(event.id).toMatch(/^evt_/);
+			expect(event.trace_id).toMatch(/^trc_/);
+			expect(event.timestamp).toBeDefined();
+			expect(event.source).toBe('gh-webhook');
+			expect(event.type).toBe('resource.changed');
+			expect(event.provenance.platform).toBe('github');
+		});
+
+		it('response includes event IDs', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'opened',
+				pull_request: samplePR,
+				repository: sampleRepo,
+			});
+			const req = createMockRequest(body, 'POST', {
+				'x-github-event': 'pull_request',
+			});
+			const res = createMockResponse();
+
+			await handler(req, res);
+			const responseBody = JSON.parse(res.body);
+			expect(responseBody.ok).toBe(true);
+			expect(responseBody.events_created).toBe(1);
+			expect(responseBody.event_ids).toHaveLength(1);
+			expect(responseBody.event_ids[0]).toMatch(/^evt_/);
+		});
+	});
+
+	// ─── normalizeWebhookPayload direct tests ────────────────────────────────
+
+	describe('normalizeWebhookPayload', () => {
+		beforeEach(async () => {
+			await source.init({
+				id: 'gh-webhook',
+				connector: '@orgloop/connector-github-webhook',
+				config: {},
+			});
+		});
+
+		it('returns empty for missing pull_request in PR event', () => {
+			const events = source.normalizeWebhookPayload('pull_request', {
+				action: 'opened',
+				repository: sampleRepo,
+			});
+			expect(events).toHaveLength(0);
+		});
+
+		it('returns empty for missing review in review event', () => {
+			const events = source.normalizeWebhookPayload('pull_request_review', {
+				action: 'submitted',
+				repository: sampleRepo,
+			});
+			expect(events).toHaveLength(0);
+		});
+
+		it('returns empty for missing comment in issue_comment event', () => {
+			const events = source.normalizeWebhookPayload('issue_comment', {
+				action: 'created',
+				repository: sampleRepo,
+			});
+			expect(events).toHaveLength(0);
+		});
+	});
+});

--- a/connectors/github-webhook/src/index.ts
+++ b/connectors/github-webhook/src/index.ts
@@ -1,0 +1,36 @@
+/**
+ * @orgloop/connector-github-webhook — GitHub webhook source connector registration.
+ *
+ * Receives GitHub webhook POST deliveries and normalizes them into OrgLoop events
+ * using the same normalizer functions as the polling GitHub connector.
+ */
+
+import type { ConnectorRegistration } from '@orgloop/sdk';
+import { GitHubWebhookSource } from './source.js';
+
+export default function register(): ConnectorRegistration {
+	return {
+		id: 'github-webhook',
+		source: GitHubWebhookSource,
+		setup: {
+			env_vars: [
+				{
+					name: 'GITHUB_WEBHOOK_SECRET',
+					description: 'HMAC-SHA256 secret for validating GitHub webhook signatures',
+					help_url:
+						'https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries',
+				},
+			],
+			integrations: [
+				{
+					id: 'github-webhook-setup',
+					description:
+						'Configure a webhook in your GitHub repository settings pointing to the OrgLoop endpoint',
+					platform: 'github',
+				},
+			],
+		},
+	};
+}
+
+export { GitHubWebhookSource } from './source.js';

--- a/connectors/github-webhook/src/source.ts
+++ b/connectors/github-webhook/src/source.ts
@@ -1,0 +1,304 @@
+/**
+ * GitHub webhook source connector — receives GitHub webhook POST deliveries
+ * and normalizes them into OrgLoop events using the same normalizers as the
+ * polling connector.
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { join } from 'node:path';
+import {
+	normalizeCheckSuiteCompleted,
+	normalizeIssueComment,
+	normalizePullRequestClosed,
+	normalizePullRequestOpened,
+	normalizePullRequestReadyForReview,
+	normalizePullRequestReview,
+	normalizePullRequestReviewComment,
+	normalizeWorkflowRunFailed,
+} from '@orgloop/connector-github';
+import type {
+	OrgLoopEvent,
+	PollResult,
+	SourceConfig,
+	SourceConnector,
+	WebhookHandler,
+} from '@orgloop/sdk';
+import { buildEvent } from '@orgloop/sdk';
+
+export interface GitHubWebhookConfig {
+	/** HMAC-SHA256 secret for validating webhook signatures */
+	secret?: string;
+	/** URL path to mount the webhook handler on */
+	path?: string;
+	/** Event types to accept (e.g., ["pull_request", "issue_comment"]) */
+	events?: string[];
+	/** Directory for persisting buffered events across restarts */
+	buffer_dir?: string;
+}
+
+/** Resolve env var references like ${WEBHOOK_SECRET} */
+function resolveEnvVar(value: string): string {
+	const match = value.match(/^\$\{(.+)\}$/);
+	if (match) {
+		const envValue = process.env[match[1]];
+		if (!envValue) {
+			throw new Error(`Environment variable ${match[1]} is not set`);
+		}
+		return envValue;
+	}
+	return value;
+}
+
+export class GitHubWebhookSource implements SourceConnector {
+	readonly id = 'github-webhook';
+	private secret?: string;
+	private sourceId = 'github-webhook';
+	private allowedEvents?: Set<string>;
+	private pendingEvents: OrgLoopEvent[] = [];
+	private bufferPath?: string;
+
+	async init(config: SourceConfig): Promise<void> {
+		this.sourceId = config.id;
+		const cfg = config.config as unknown as GitHubWebhookConfig;
+
+		if (cfg.secret) {
+			this.secret = resolveEnvVar(cfg.secret);
+		}
+
+		if (cfg.events && cfg.events.length > 0) {
+			this.allowedEvents = new Set(cfg.events);
+		}
+
+		if (cfg.buffer_dir) {
+			const dir = resolveEnvVar(cfg.buffer_dir);
+			if (!existsSync(dir)) {
+				mkdirSync(dir, { recursive: true });
+			}
+			this.bufferPath = join(dir, `github-webhook-${this.sourceId}.jsonl`);
+			this.loadBufferedEvents();
+		}
+	}
+
+	async poll(_checkpoint: string | null): Promise<PollResult> {
+		let events: OrgLoopEvent[];
+		if (this.bufferPath) {
+			events = this.loadBufferedEvents();
+			writeFileSync(this.bufferPath, '');
+		} else {
+			events = [...this.pendingEvents];
+			this.pendingEvents = [];
+		}
+		const checkpoint =
+			events.length > 0 ? events[events.length - 1].timestamp : new Date().toISOString();
+		return { events, checkpoint };
+	}
+
+	webhook(): WebhookHandler {
+		return async (req: IncomingMessage, res: ServerResponse): Promise<OrgLoopEvent[]> => {
+			if (req.method !== 'POST') {
+				res.writeHead(405, { 'Content-Type': 'application/json' });
+				res.end(JSON.stringify({ error: 'Method not allowed' }));
+				return [];
+			}
+
+			const bodyStr = await readBody(req);
+
+			// HMAC-SHA256 signature validation
+			if (this.secret) {
+				const signature = req.headers['x-hub-signature-256'] as string | undefined;
+				if (!signature) {
+					res.writeHead(401, { 'Content-Type': 'application/json' });
+					res.end(JSON.stringify({ error: 'Missing X-Hub-Signature-256 header' }));
+					return [];
+				}
+
+				const expected = `sha256=${createHmac('sha256', this.secret).update(bodyStr).digest('hex')}`;
+				const sigBuffer = Buffer.from(signature);
+				const expectedBuffer = Buffer.from(expected);
+				if (
+					sigBuffer.length !== expectedBuffer.length ||
+					!timingSafeEqual(sigBuffer, expectedBuffer)
+				) {
+					res.writeHead(401, { 'Content-Type': 'application/json' });
+					res.end(JSON.stringify({ error: 'Invalid signature' }));
+					return [];
+				}
+			}
+
+			// Parse the webhook event type from GitHub headers
+			const githubEvent = req.headers['x-github-event'] as string | undefined;
+			if (!githubEvent) {
+				res.writeHead(400, { 'Content-Type': 'application/json' });
+				res.end(JSON.stringify({ error: 'Missing X-GitHub-Event header' }));
+				return [];
+			}
+
+			let payload: Record<string, unknown>;
+			try {
+				payload = JSON.parse(bodyStr) as Record<string, unknown>;
+			} catch {
+				res.writeHead(400, { 'Content-Type': 'application/json' });
+				res.end(JSON.stringify({ error: 'Invalid JSON payload' }));
+				return [];
+			}
+
+			const events = this.normalizeWebhookPayload(githubEvent, payload);
+
+			for (const event of events) {
+				this.persistEvent(event);
+			}
+
+			res.writeHead(200, { 'Content-Type': 'application/json' });
+			res.end(
+				JSON.stringify({
+					ok: true,
+					events_created: events.length,
+					event_ids: events.map((e) => e.id),
+				}),
+			);
+			return events;
+		};
+	}
+
+	async shutdown(): Promise<void> {
+		this.pendingEvents = [];
+	}
+
+	/**
+	 * Normalize a GitHub webhook payload into OrgLoop events.
+	 * Uses the same normalizer functions as the polling connector.
+	 */
+	normalizeWebhookPayload(githubEvent: string, payload: Record<string, unknown>): OrgLoopEvent[] {
+		const action = payload.action as string | undefined;
+		const repo = (payload.repository as Record<string, unknown>) ?? {};
+
+		switch (githubEvent) {
+			case 'pull_request_review': {
+				if (!this.isEventAllowed('pull_request.review_submitted')) return [];
+				const review = payload.review as Record<string, unknown>;
+				const pr = payload.pull_request as Record<string, unknown>;
+				if (!review || !pr) return [];
+				return [normalizePullRequestReview(this.sourceId, review, pr, repo)];
+			}
+
+			case 'pull_request_review_comment': {
+				if (!this.isEventAllowed('pull_request_review_comment')) return [];
+				const comment = payload.comment as Record<string, unknown>;
+				const pr = payload.pull_request as Record<string, unknown>;
+				if (!comment || !pr) return [];
+				return [normalizePullRequestReviewComment(this.sourceId, comment, pr, repo)];
+			}
+
+			case 'issue_comment': {
+				if (!this.isEventAllowed('issue_comment')) return [];
+				const comment = payload.comment as Record<string, unknown>;
+				const issue = payload.issue as Record<string, unknown>;
+				if (!comment || !issue) return [];
+				return [normalizeIssueComment(this.sourceId, comment, issue, repo)];
+			}
+
+			case 'pull_request': {
+				const pr = payload.pull_request as Record<string, unknown>;
+				if (!pr) return [];
+
+				if (action === 'closed') {
+					if (
+						!this.isEventAllowed('pull_request.closed') &&
+						!this.isEventAllowed('pull_request.merged')
+					)
+						return [];
+					return [normalizePullRequestClosed(this.sourceId, pr, repo)];
+				}
+				if (action === 'opened') {
+					if (!this.isEventAllowed('pull_request.opened')) return [];
+					return [normalizePullRequestOpened(this.sourceId, pr, repo)];
+				}
+				if (action === 'ready_for_review') {
+					if (!this.isEventAllowed('pull_request.ready_for_review')) return [];
+					return [normalizePullRequestReadyForReview(this.sourceId, pr, repo)];
+				}
+				// Unhandled pull_request action — emit raw event
+				return this.buildRawEvent(githubEvent, action, payload);
+			}
+
+			case 'workflow_run': {
+				if (!this.isEventAllowed('workflow_run.completed')) return [];
+				if (action !== 'completed') return [];
+				const run = payload.workflow_run as Record<string, unknown>;
+				if (!run) return [];
+				const conclusion = run.conclusion as string;
+				if (conclusion === 'failure') {
+					return [normalizeWorkflowRunFailed(this.sourceId, run, repo)];
+				}
+				// Non-failure workflow runs — emit raw event
+				return this.buildRawEvent(githubEvent, action, payload);
+			}
+
+			case 'check_suite': {
+				if (!this.isEventAllowed('check_suite.completed')) return [];
+				if (action !== 'completed') return [];
+				const suite = payload.check_suite as Record<string, unknown>;
+				if (!suite) return [];
+				return [normalizeCheckSuiteCompleted(this.sourceId, suite, repo)];
+			}
+
+			default:
+				// Unknown event type — emit raw event for extensibility
+				return this.buildRawEvent(githubEvent, action, payload);
+		}
+	}
+
+	private isEventAllowed(eventType: string): boolean {
+		if (!this.allowedEvents) return true;
+		return this.allowedEvents.has(eventType);
+	}
+
+	private buildRawEvent(
+		githubEvent: string,
+		action: string | undefined,
+		payload: Record<string, unknown>,
+	): OrgLoopEvent[] {
+		const platformEvent = action ? `${githubEvent}.${action}` : githubEvent;
+		return [
+			buildEvent({
+				source: this.sourceId,
+				type: 'resource.changed',
+				provenance: {
+					platform: 'github',
+					platform_event: platformEvent,
+				},
+				payload,
+			}),
+		];
+	}
+
+	private persistEvent(event: OrgLoopEvent): void {
+		if (this.bufferPath) {
+			appendFileSync(this.bufferPath, `${JSON.stringify(event)}\n`);
+		} else {
+			this.pendingEvents.push(event);
+		}
+	}
+
+	private loadBufferedEvents(): OrgLoopEvent[] {
+		if (!this.bufferPath || !existsSync(this.bufferPath)) {
+			return [];
+		}
+		const content = readFileSync(this.bufferPath, 'utf-8').trim();
+		if (!content) {
+			return [];
+		}
+		return content.split('\n').map((line) => JSON.parse(line) as OrgLoopEvent);
+	}
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		req.on('data', (chunk: Buffer) => chunks.push(chunk));
+		req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+		req.on('error', reject);
+	});
+}

--- a/connectors/github-webhook/tsconfig.json
+++ b/connectors/github-webhook/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"],
+  "references": [
+    { "path": "../../packages/sdk" }
+  ]
+}

--- a/connectors/github/README.md
+++ b/connectors/github/README.md
@@ -119,4 +119,4 @@ routes:
 - **Rate limits** -- GitHub API rate limits apply (5,000 requests/hour for authenticated requests). The connector backs off gracefully on 429 responses but high-frequency polling of repos with many open PRs can consume quota quickly.
 - **Per-page limits** -- Review polling fetches up to 30 recently updated PRs and their reviews. Very active repos may miss reviews on older PRs.
 - **Bot detection** -- Authors with `[bot]` suffix or GitHub `type: "Bot"` are classified as `author_type: "bot"`.
-- **No webhook receiver** -- Unlike `connector-webhook`, this connector has no webhook handler; it only polls.
+- **No webhook receiver** -- This connector only polls. For real-time webhook delivery, use `@orgloop/connector-github-webhook`, which produces identical events with zero latency. The two connectors can coexist (webhook for real-time, polling as fallback).

--- a/connectors/github/src/index.ts
+++ b/connectors/github/src/index.ts
@@ -6,6 +6,17 @@ import type { ConnectorRegistration } from '@orgloop/sdk';
 import { GitHubSource } from './source.js';
 import { GitHubCredentialValidator } from './validator.js';
 
+export {
+	normalizeCheckSuiteCompleted,
+	normalizeIssueComment,
+	normalizePullRequestClosed,
+	normalizePullRequestOpened,
+	normalizePullRequestReadyForReview,
+	normalizePullRequestReview,
+	normalizePullRequestReviewComment,
+	normalizeWorkflowRunFailed,
+} from './normalizer.js';
+
 export default function register(): ConnectorRegistration {
 	return {
 		id: 'github',

--- a/docs-site/src/content/docs/spec/plugin-system.md
+++ b/docs-site/src/content/docs/spec/plugin-system.md
@@ -40,7 +40,8 @@ Downloads the SEA binary for the detected platform. Yes, `curl | bash` is ironic
 **Bundled connectors (first-party):**
 
 The `@orgloop/cli` package includes a "batteries-included" set of common connectors:
-- `@orgloop/connector-github`
+- `@orgloop/connector-github` (poll-based)
+- `@orgloop/connector-github-webhook` (webhook-based, real-time)
 - `@orgloop/connector-webhook`
 
 Additional first-party connectors are installed separately:

--- a/docs-site/src/content/docs/spec/repo-organization.md
+++ b/docs-site/src/content/docs/spec/repo-organization.md
@@ -95,6 +95,11 @@ orgloop/
 │   │       ├── normalizer.ts    # GitHub events → OrgLoop event types
 │   │       └── validator.ts     # Credential validation
 │   │
+│   ├── github-webhook/          # @orgloop/connector-github-webhook
+│   │   └── src/
+│   │       ├── index.ts         # Connector registration
+│   │       └── source.ts        # GitHub webhook source (push-based, reuses github normalizers)
+│   │
 │   ├── linear/                  # @orgloop/connector-linear
 │   │   └── src/
 │   │       ├── index.ts

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,7 @@
     "@orgloop/connector-cron": "workspace:*",
     "@orgloop/connector-docker": "workspace:*",
     "@orgloop/connector-github": "workspace:*",
+    "@orgloop/connector-github-webhook": "workspace:*",
     "@orgloop/connector-gog": "workspace:*",
     "@orgloop/connector-linear": "workspace:*",
     "@orgloop/connector-opencode": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,15 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sdk
 
+  connectors/github-webhook:
+    dependencies:
+      '@orgloop/connector-github':
+        specifier: workspace:*
+        version: link:../github
+      '@orgloop/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+
   connectors/gog:
     dependencies:
       '@orgloop/sdk':
@@ -211,6 +220,9 @@ importers:
       '@orgloop/connector-github':
         specifier: workspace:*
         version: link:../../connectors/github
+      '@orgloop/connector-github-webhook':
+        specifier: workspace:*
+        version: link:../../connectors/github-webhook
       '@orgloop/connector-gog':
         specifier: workspace:*
         version: link:../../connectors/gog


### PR DESCRIPTION
Closes #108

New `@orgloop/connector-github-webhook` package — push-based GitHub connector that receives webhook POSTs in real-time.

**Features:**
- HMAC-SHA256 signature validation (timing-safe)
- Reuses all normalizer functions from the polling connector — identical OrgLoop events
- Event filtering via `config.events` (same list as polling connector)
- Buffer persistence (`buffer_dir`) for crash recovery
- Coexists with polling connector (webhook for speed, polling for reliability)

31 new tests. 1,397 lines added.