### PR TITLE
feat(connector-openclaw): forward model, thinking, timeout from route config

### DIFF
--- a/connectors/openclaw/src/target.ts
+++ b/connectors/openclaw/src/target.ts
@@ -118,6 +118,9 @@ export class OpenClawTarget implements ActorConnector {
 				channel: (routeConfig.channel as string) ?? this.defaultChannel,
 				to: (routeConfig.to as string) ?? this.defaultTo,
 				...(threadId !== undefined ? { threadId } : {}),
+				...(routeConfig.model ? { model: routeConfig.model } : {}),
+				...(routeConfig.thinking ? { thinking: routeConfig.thinking } : {}),
+				...(routeConfig.timeout_seconds ? { timeoutSeconds: routeConfig.timeout_seconds } : {}),
 			});
 			if (callbackResult.status === 'delivered') {
 				return callbackResult;
@@ -134,6 +137,9 @@ export class OpenClawTarget implements ActorConnector {
 			channel: (routeConfig.channel as string) ?? this.defaultChannel,
 			to: (routeConfig.to as string) ?? this.defaultTo,
 			...(threadId !== undefined ? { threadId } : {}),
+			...(routeConfig.model ? { model: routeConfig.model } : {}),
+			...(routeConfig.thinking ? { thinking: routeConfig.thinking } : {}),
+			...(routeConfig.timeout_seconds ? { timeoutSeconds: routeConfig.timeout_seconds } : {}),
 		});
 	}
 


### PR DESCRIPTION
The OpenClaw `/hooks/agent` API supports `model`, `thinking`, and `timeoutSeconds` fields, but the connector wasn't forwarding them from route config.

This adds passthrough for all three fields in both the callback and normal delivery paths:
- `model` → model override (e.g. `ohm/moonshotai/Kimi-K2.5`)
- `thinking` → thinking level override (e.g. `high`)
- `timeout_seconds` → mapped to `timeoutSeconds` for the API

**Usage in route YAML:**
```yaml
then:
  actor: openclaw-engineering-agent
  config:
    model: "ohm/moonshotai/Kimi-K2.5"
    thinking: "high"
    timeout_seconds: 600
```

Tests pass, typecheck clean.