### PR TITLE
feat: add Linear webhook connector for real-time events

### DIFF
--- a/connectors/linear-webhook/package.json
+++ b/connectors/linear-webhook/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@orgloop/connector-linear-webhook",
+  "version": "0.1.0",
+  "description": "OrgLoop Linear webhook connector — real-time event delivery via Linear webhooks",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@orgloop/sdk": "workspace:*",
+    "@orgloop/connector-linear": "workspace:*"
+  },
+  "orgloop": {
+    "type": "connector",
+    "provides": [
+      "source"
+    ],
+    "id": "linear-webhook"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT"
+}

--- a/connectors/linear-webhook/src/__tests__/source.test.ts
+++ b/connectors/linear-webhook/src/__tests__/source.test.ts
@@ -1,0 +1,748 @@
+import { createHmac } from 'node:crypto';
+import { EventEmitter } from 'node:events';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LinearWebhookSource } from '../source.js';
+
+const TEST_SECRET = 'test-linear-webhook-secret';
+
+function createMockRequest(
+	body: string,
+	method = 'POST',
+	headers: Record<string, string> = {},
+): IncomingMessage {
+	const req = new EventEmitter() as unknown as IncomingMessage;
+	req.method = method;
+	req.headers = { ...headers };
+	setTimeout(() => {
+		(req as EventEmitter).emit('data', Buffer.from(body));
+		(req as EventEmitter).emit('end');
+	}, 0);
+	return req;
+}
+
+function createMockResponse(): ServerResponse & { statusCode: number; body: string } {
+	const res = {
+		statusCode: 200,
+		body: '',
+		writeHead(code: number, _headers?: Record<string, string>) {
+			res.statusCode = code;
+			return res;
+		},
+		end(data?: string) {
+			res.body = data ?? '';
+			return res;
+		},
+	} as unknown as ServerResponse & { statusCode: number; body: string };
+	return res;
+}
+
+function signPayload(body: string, secret: string): string {
+	return createHmac('sha256', secret).update(body).digest('hex');
+}
+
+// ─── Sample Linear webhook payloads ──────────────────────────────────────────
+
+const sampleIssueCreated = {
+	action: 'create',
+	createdAt: '2024-01-15T10:00:00.000Z',
+	type: 'Issue',
+	url: 'https://linear.app/team/issue/TEAM-42',
+	data: {
+		id: 'issue-uuid-1',
+		identifier: 'TEAM-42',
+		title: 'Fix login bug',
+		description: 'Login fails on mobile',
+		url: 'https://linear.app/team/issue/TEAM-42',
+		state: { name: 'Todo' },
+		creator: { name: 'Alice', isBot: false },
+		assignee: { name: 'Bob', isBot: false },
+		createdAt: '2024-01-15T10:00:00.000Z',
+		updatedAt: '2024-01-15T10:00:00.000Z',
+		priority: 2,
+		labels: [],
+		team: { key: 'TEAM' },
+	},
+};
+
+const sampleIssueStateChanged = {
+	action: 'update',
+	createdAt: '2024-01-15T11:00:00.000Z',
+	type: 'Issue',
+	url: 'https://linear.app/team/issue/TEAM-42',
+	updatedFrom: {
+		state: { name: 'Todo' },
+	},
+	data: {
+		id: 'issue-uuid-1',
+		identifier: 'TEAM-42',
+		title: 'Fix login bug',
+		url: 'https://linear.app/team/issue/TEAM-42',
+		state: { name: 'In Progress' },
+		assignee: { name: 'Bob', isBot: false },
+		creator: { name: 'Alice', isBot: false },
+		createdAt: '2024-01-15T10:00:00.000Z',
+		updatedAt: '2024-01-15T11:00:00.000Z',
+		priority: 2,
+		labels: [],
+		team: { key: 'TEAM' },
+	},
+};
+
+const sampleIssueAssigneeChanged = {
+	action: 'update',
+	createdAt: '2024-01-15T12:00:00.000Z',
+	type: 'Issue',
+	url: 'https://linear.app/team/issue/TEAM-42',
+	updatedFrom: {
+		assigneeId: 'old-user-id',
+		assignee: { name: 'Bob' },
+	},
+	data: {
+		id: 'issue-uuid-1',
+		identifier: 'TEAM-42',
+		title: 'Fix login bug',
+		url: 'https://linear.app/team/issue/TEAM-42',
+		state: { name: 'In Progress' },
+		assignee: { name: 'Carol', isBot: false },
+		creator: { name: 'Alice', isBot: false },
+		createdAt: '2024-01-15T10:00:00.000Z',
+		updatedAt: '2024-01-15T12:00:00.000Z',
+		priority: 2,
+		labels: [],
+		team: { key: 'TEAM' },
+	},
+};
+
+const sampleIssuePriorityChanged = {
+	action: 'update',
+	createdAt: '2024-01-15T13:00:00.000Z',
+	type: 'Issue',
+	url: 'https://linear.app/team/issue/TEAM-42',
+	updatedFrom: {
+		priority: 2,
+	},
+	data: {
+		id: 'issue-uuid-1',
+		identifier: 'TEAM-42',
+		title: 'Fix login bug',
+		url: 'https://linear.app/team/issue/TEAM-42',
+		state: { name: 'In Progress' },
+		assignee: { name: 'Bob', isBot: false },
+		createdAt: '2024-01-15T10:00:00.000Z',
+		updatedAt: '2024-01-15T13:00:00.000Z',
+		priority: 1,
+		labels: [],
+		team: { key: 'TEAM' },
+	},
+};
+
+const sampleIssueLabelChanged = {
+	action: 'update',
+	createdAt: '2024-01-15T14:00:00.000Z',
+	type: 'Issue',
+	url: 'https://linear.app/team/issue/TEAM-42',
+	updatedFrom: {
+		labelIds: ['label-1'],
+		labels: [{ name: 'bug' }],
+	},
+	data: {
+		id: 'issue-uuid-1',
+		identifier: 'TEAM-42',
+		title: 'Fix login bug',
+		url: 'https://linear.app/team/issue/TEAM-42',
+		state: { name: 'In Progress' },
+		assignee: { name: 'Bob', isBot: false },
+		createdAt: '2024-01-15T10:00:00.000Z',
+		updatedAt: '2024-01-15T14:00:00.000Z',
+		priority: 2,
+		labels: [{ name: 'bug' }, { name: 'urgent' }],
+		team: { key: 'TEAM' },
+	},
+};
+
+const sampleCommentCreated = {
+	action: 'create',
+	createdAt: '2024-01-15T11:30:00.000Z',
+	type: 'Comment',
+	url: 'https://linear.app/team/issue/TEAM-42#comment-1',
+	data: {
+		id: 'comment-uuid-1',
+		body: 'I can reproduce this on iOS 17',
+		url: 'https://linear.app/team/issue/TEAM-42#comment-1',
+		createdAt: '2024-01-15T11:30:00.000Z',
+		user: { name: 'Alice', isBot: false },
+		issue: {
+			identifier: 'TEAM-42',
+			title: 'Fix login bug',
+			assignee: { name: 'Bob' },
+			creator: { name: 'Alice' },
+		},
+	},
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('LinearWebhookSource', () => {
+	let source: LinearWebhookSource;
+
+	beforeEach(() => {
+		source = new LinearWebhookSource();
+	});
+
+	afterEach(async () => {
+		await source.shutdown();
+	});
+
+	// ─── Initialization ──────────────────────────────────────────────────────
+
+	it('initializes without error', async () => {
+		await source.init({
+			id: 'linear-wh',
+			connector: '@orgloop/connector-linear-webhook',
+			config: {},
+		});
+		expect(source.id).toBe('linear-webhook');
+	});
+
+	it('returns empty events on initial poll', async () => {
+		await source.init({
+			id: 'linear-wh',
+			connector: '@orgloop/connector-linear-webhook',
+			config: {},
+		});
+		const result = await source.poll(null);
+		expect(result.events).toHaveLength(0);
+		expect(result.checkpoint).toBeDefined();
+	});
+
+	// ─── Signature validation ────────────────────────────────────────────────
+
+	describe('HMAC signature validation', () => {
+		beforeEach(async () => {
+			process.env.TEST_LINEAR_WEBHOOK_SECRET = TEST_SECRET;
+			await source.init({
+				id: 'linear-wh',
+				connector: '@orgloop/connector-linear-webhook',
+				config: { secret: '${TEST_LINEAR_WEBHOOK_SECRET}' },
+			});
+		});
+
+		afterEach(() => {
+			delete process.env.TEST_LINEAR_WEBHOOK_SECRET;
+		});
+
+		it('accepts valid signature', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify(sampleIssueCreated);
+			const req = createMockRequest(body, 'POST', {
+				'linear-signature': signPayload(body, TEST_SECRET),
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(res.statusCode).toBe(200);
+			expect(events).toHaveLength(1);
+		});
+
+		it('rejects missing signature', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify(sampleIssueCreated);
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(res.statusCode).toBe(401);
+			expect(events).toHaveLength(0);
+			expect(JSON.parse(res.body).error).toContain('Missing');
+		});
+
+		it('rejects invalid signature', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify(sampleIssueCreated);
+			const req = createMockRequest(body, 'POST', {
+				'linear-signature': 'deadbeef',
+			});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(res.statusCode).toBe(401);
+			expect(events).toHaveLength(0);
+			expect(JSON.parse(res.body).error).toContain('Invalid signature');
+		});
+	});
+
+	// ─── Request validation ──────────────────────────────────────────────────
+
+	describe('request validation', () => {
+		beforeEach(async () => {
+			await source.init({
+				id: 'linear-wh',
+				connector: '@orgloop/connector-linear-webhook',
+				config: {},
+			});
+		});
+
+		it('rejects non-POST requests', async () => {
+			const handler = source.webhook();
+			const req = createMockRequest('', 'GET', {});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(res.statusCode).toBe(405);
+			expect(events).toHaveLength(0);
+		});
+
+		it('rejects invalid JSON', async () => {
+			const handler = source.webhook();
+			const req = createMockRequest('not-json', 'POST', {});
+			const res = createMockResponse();
+
+			await handler(req, res);
+			expect(res.statusCode).toBe(400);
+			expect(JSON.parse(res.body).error).toContain('Invalid JSON');
+		});
+
+		it('rejects payloads without type or action', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({ data: {} });
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			await handler(req, res);
+			expect(res.statusCode).toBe(400);
+			expect(JSON.parse(res.body).error).toContain('type or action');
+		});
+	});
+
+	// ─── Issue events ────────────────────────────────────────────────────────
+
+	describe('Issue events', () => {
+		beforeEach(async () => {
+			await source.init({
+				id: 'linear-wh',
+				connector: '@orgloop/connector-linear-webhook',
+				config: {},
+			});
+		});
+
+		it('normalizes issue.created', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify(sampleIssueCreated);
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(res.statusCode).toBe(200);
+			expect(events).toHaveLength(1);
+			expect(events[0].type).toBe('resource.changed');
+			expect(events[0].provenance.platform).toBe('linear');
+			expect(events[0].provenance.platform_event).toBe('issue.created');
+			expect(events[0].provenance.issue_id).toBe('TEAM-42');
+			expect(events[0].payload.action).toBe('issue_created');
+			expect(events[0].payload.issue_id).toBe('TEAM-42');
+			expect(events[0].payload.issue_title).toBe('Fix login bug');
+		});
+
+		it('normalizes issue state change', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify(sampleIssueStateChanged);
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform_event).toBe('issue.state_changed');
+			expect(events[0].payload.action).toBe('state_changed');
+			expect(events[0].payload.previous_state).toBe('Todo');
+			expect(events[0].payload.new_state).toBe('In Progress');
+		});
+
+		it('normalizes issue assignee change', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify(sampleIssueAssigneeChanged);
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform_event).toBe('issue.assignee_changed');
+			expect(events[0].payload.action).toBe('assignee_changed');
+			expect(events[0].payload.previous_assignee).toBe('Bob');
+			expect(events[0].payload.new_assignee).toBe('Carol');
+		});
+
+		it('normalizes issue priority change', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify(sampleIssuePriorityChanged);
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform_event).toBe('issue.priority_changed');
+			expect(events[0].payload.action).toBe('priority_changed');
+			expect(events[0].payload.previous_priority).toBe(2);
+			expect(events[0].payload.new_priority).toBe(1);
+		});
+
+		it('normalizes issue label change', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify(sampleIssueLabelChanged);
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform_event).toBe('issue.labels_changed');
+			expect(events[0].payload.action).toBe('labels_changed');
+			expect(events[0].payload.added_labels).toContain('urgent');
+		});
+
+		it('emits raw event for issue removal', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'remove',
+				type: 'Issue',
+				data: { id: 'issue-uuid-1', identifier: 'TEAM-42' },
+			});
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform_event).toBe('issue.remove');
+		});
+	});
+
+	// ─── Comment events ──────────────────────────────────────────────────────
+
+	describe('Comment events', () => {
+		beforeEach(async () => {
+			await source.init({
+				id: 'linear-wh',
+				connector: '@orgloop/connector-linear-webhook',
+				config: {},
+			});
+		});
+
+		it('normalizes comment.created', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify(sampleCommentCreated);
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].type).toBe('resource.changed');
+			expect(events[0].provenance.platform).toBe('linear');
+			expect(events[0].provenance.platform_event).toBe('comment.created');
+			expect(events[0].provenance.author).toBe('Alice');
+			expect(events[0].provenance.issue_id).toBe('TEAM-42');
+			expect(events[0].payload.action).toBe('comment_created');
+			expect(events[0].payload.comment_body).toBe('I can reproduce this on iOS 17');
+		});
+
+		it('emits raw event for comment update', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'update',
+				type: 'Comment',
+				data: { id: 'comment-uuid-1', body: 'Updated body' },
+			});
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform_event).toBe('comment.update');
+		});
+	});
+
+	// ─── Event filtering ─────────────────────────────────────────────────────
+
+	describe('event filtering', () => {
+		it('only accepts configured resource types', async () => {
+			await source.init({
+				id: 'linear-wh',
+				connector: '@orgloop/connector-linear-webhook',
+				config: { events: ['Issue'] },
+			});
+
+			const handler = source.webhook();
+
+			// Allowed: Issue
+			const body1 = JSON.stringify(sampleIssueCreated);
+			const req1 = createMockRequest(body1, 'POST', {});
+			const res1 = createMockResponse();
+			const events1 = await handler(req1, res1);
+			expect(events1).toHaveLength(1);
+
+			// Blocked: Comment
+			const body2 = JSON.stringify(sampleCommentCreated);
+			const req2 = createMockRequest(body2, 'POST', {});
+			const res2 = createMockResponse();
+			const events2 = await handler(req2, res2);
+			expect(events2).toHaveLength(0);
+		});
+
+		it('accepts all events when no filter is configured', async () => {
+			await source.init({
+				id: 'linear-wh',
+				connector: '@orgloop/connector-linear-webhook',
+				config: {},
+			});
+
+			const handler = source.webhook();
+			const body = JSON.stringify(sampleCommentCreated);
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+		});
+	});
+
+	// ─── Team filtering ──────────────────────────────────────────────────────
+
+	describe('team filtering', () => {
+		it('accepts events for the configured team', async () => {
+			await source.init({
+				id: 'linear-wh',
+				connector: '@orgloop/connector-linear-webhook',
+				config: { team: 'TEAM' },
+			});
+
+			const handler = source.webhook();
+			const body = JSON.stringify(sampleIssueCreated);
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+		});
+
+		it('rejects events for a different team', async () => {
+			await source.init({
+				id: 'linear-wh',
+				connector: '@orgloop/connector-linear-webhook',
+				config: { team: 'OTHER' },
+			});
+
+			const handler = source.webhook();
+			const body = JSON.stringify(sampleIssueCreated);
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(res.statusCode).toBe(200);
+			expect(events).toHaveLength(0);
+			expect(JSON.parse(res.body).filtered).toBe(true);
+		});
+	});
+
+	// ─── Unknown event types ─────────────────────────────────────────────────
+
+	describe('unknown event types', () => {
+		beforeEach(async () => {
+			await source.init({
+				id: 'linear-wh',
+				connector: '@orgloop/connector-linear-webhook',
+				config: {},
+			});
+		});
+
+		it('emits raw events for unknown resource types', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify({
+				action: 'create',
+				type: 'Project',
+				data: { id: 'project-1', name: 'New Project' },
+			});
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform).toBe('linear');
+			expect(events[0].provenance.platform_event).toBe('project.create');
+			expect(events[0].type).toBe('resource.changed');
+		});
+	});
+
+	// ─── Poll draining ───────────────────────────────────────────────────────
+
+	describe('poll drains webhook buffer', () => {
+		beforeEach(async () => {
+			await source.init({
+				id: 'linear-wh',
+				connector: '@orgloop/connector-linear-webhook',
+				config: {},
+			});
+		});
+
+		it('poll returns events received via webhook', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify(sampleIssueCreated);
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			await handler(req, res);
+
+			const result = await source.poll(null);
+			expect(result.events).toHaveLength(1);
+			expect(result.events[0].provenance.platform_event).toBe('issue.created');
+
+			// Second poll returns empty
+			const result2 = await source.poll(result.checkpoint);
+			expect(result2.events).toHaveLength(0);
+		});
+	});
+
+	// ─── Buffer persistence ──────────────────────────────────────────────────
+
+	describe('buffer persistence', () => {
+		let bufferDir: string;
+
+		beforeEach(() => {
+			bufferDir = join(tmpdir(), `orgloop-linear-webhook-test-${Date.now()}`);
+			mkdirSync(bufferDir, { recursive: true });
+		});
+
+		afterEach(() => {
+			if (existsSync(bufferDir)) {
+				rmSync(bufferDir, { recursive: true });
+			}
+		});
+
+		it('persists events to disk when buffer_dir is set', async () => {
+			await source.init({
+				id: 'linear-wh',
+				connector: '@orgloop/connector-linear-webhook',
+				config: { buffer_dir: bufferDir },
+			});
+
+			const handler = source.webhook();
+			const body = JSON.stringify(sampleIssueCreated);
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			await handler(req, res);
+
+			// Create a new source instance to verify persistence
+			const source2 = new LinearWebhookSource();
+			await source2.init({
+				id: 'linear-wh',
+				connector: '@orgloop/connector-linear-webhook',
+				config: { buffer_dir: bufferDir },
+			});
+
+			const result = await source2.poll(null);
+			expect(result.events).toHaveLength(1);
+			expect(result.events[0].provenance.platform_event).toBe('issue.created');
+			await source2.shutdown();
+		});
+	});
+
+	// ─── Event structure ─────────────────────────────────────────────────────
+
+	describe('event structure', () => {
+		beforeEach(async () => {
+			await source.init({
+				id: 'linear-wh',
+				connector: '@orgloop/connector-linear-webhook',
+				config: {},
+			});
+		});
+
+		it('produces well-formed OrgLoop events', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify(sampleIssueCreated);
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			const events = await handler(req, res);
+			expect(events).toHaveLength(1);
+			const event = events[0];
+			expect(event.id).toMatch(/^evt_/);
+			expect(event.trace_id).toMatch(/^trc_/);
+			expect(event.timestamp).toBeDefined();
+			expect(event.source).toBe('linear-wh');
+			expect(event.type).toBe('resource.changed');
+			expect(event.provenance.platform).toBe('linear');
+		});
+
+		it('response includes event IDs', async () => {
+			const handler = source.webhook();
+			const body = JSON.stringify(sampleIssueCreated);
+			const req = createMockRequest(body, 'POST', {});
+			const res = createMockResponse();
+
+			await handler(req, res);
+			const responseBody = JSON.parse(res.body);
+			expect(responseBody.ok).toBe(true);
+			expect(responseBody.events_created).toBe(1);
+			expect(responseBody.event_ids).toHaveLength(1);
+			expect(responseBody.event_ids[0]).toMatch(/^evt_/);
+		});
+	});
+
+	// ─── normalizeWebhookPayload direct tests ────────────────────────────────
+
+	describe('normalizeWebhookPayload', () => {
+		beforeEach(async () => {
+			await source.init({
+				id: 'linear-wh',
+				connector: '@orgloop/connector-linear-webhook',
+				config: {},
+			});
+		});
+
+		it('returns empty for missing data field', () => {
+			const events = source.normalizeWebhookPayload('Issue', 'create', {});
+			expect(events).toHaveLength(0);
+		});
+
+		it('handles update without updatedFrom as raw event', () => {
+			const events = source.normalizeWebhookPayload('Issue', 'update', {
+				data: { id: 'issue-1', identifier: 'TEAM-1' },
+			});
+			expect(events).toHaveLength(1);
+			expect(events[0].provenance.platform_event).toBe('issue.update');
+		});
+
+		it('produces identical event shape as polling connector for issue.created', () => {
+			const events = source.normalizeWebhookPayload('Issue', 'create', sampleIssueCreated);
+			expect(events).toHaveLength(1);
+			const event = events[0];
+			// These fields match what the polling connector produces via normalizeNewIssue
+			expect(event.provenance.platform).toBe('linear');
+			expect(event.provenance.platform_event).toBe('issue.created');
+			expect(event.provenance.author).toBe('Alice');
+			expect(event.provenance.author_type).toBe('team_member');
+			expect(event.provenance.issue_id).toBe('TEAM-42');
+			expect(event.provenance.state).toBe('Todo');
+			expect(event.payload.action).toBe('issue_created');
+			expect(event.payload.issue_id).toBe('TEAM-42');
+			expect(event.payload.issue_title).toBe('Fix login bug');
+			expect(event.payload.issue_description).toBe('Login fails on mobile');
+		});
+
+		it('produces identical event shape as polling connector for comment.created', () => {
+			const events = source.normalizeWebhookPayload('Comment', 'create', sampleCommentCreated);
+			expect(events).toHaveLength(1);
+			const event = events[0];
+			expect(event.provenance.platform).toBe('linear');
+			expect(event.provenance.platform_event).toBe('comment.created');
+			expect(event.provenance.author).toBe('Alice');
+			expect(event.provenance.issue_id).toBe('TEAM-42');
+			expect(event.provenance.issue_assignee).toBe('Bob');
+			expect(event.provenance.issue_creator).toBe('Alice');
+			expect(event.payload.action).toBe('comment_created');
+			expect(event.payload.comment_body).toBe('I can reproduce this on iOS 17');
+		});
+	});
+});

--- a/connectors/linear-webhook/src/index.ts
+++ b/connectors/linear-webhook/src/index.ts
@@ -1,0 +1,35 @@
+/**
+ * @orgloop/connector-linear-webhook — Linear webhook source connector registration.
+ *
+ * Receives Linear webhook POST deliveries and normalizes them into OrgLoop events
+ * using the same normalizer functions as the polling Linear connector.
+ */
+
+import type { ConnectorRegistration } from '@orgloop/sdk';
+import { LinearWebhookSource } from './source.js';
+
+export default function register(): ConnectorRegistration {
+	return {
+		id: 'linear-webhook',
+		source: LinearWebhookSource,
+		setup: {
+			env_vars: [
+				{
+					name: 'LINEAR_WEBHOOK_SECRET',
+					description: 'HMAC signing secret for validating Linear webhook payloads',
+					help_url: 'https://developers.linear.app/docs/graphql/webhooks',
+				},
+			],
+			integrations: [
+				{
+					id: 'linear-webhook-setup',
+					description:
+						'Configure a webhook in your Linear workspace settings pointing to the OrgLoop endpoint',
+					platform: 'linear',
+				},
+			],
+		},
+	};
+}
+
+export { LinearWebhookSource } from './source.js';

--- a/connectors/linear-webhook/src/source.ts
+++ b/connectors/linear-webhook/src/source.ts
@@ -1,0 +1,376 @@
+/**
+ * Linear webhook source connector — receives Linear webhook POST deliveries
+ * and normalizes them into OrgLoop events using the same normalizers as the
+ * polling connector.
+ *
+ * Linear webhook payload shape:
+ *   { action, createdAt, data, type, url, updatedFrom }
+ *
+ * Signature: Linear-Signature header, HMAC-SHA256 of raw body with signing secret.
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { join } from 'node:path';
+import {
+	normalizeAssigneeChange,
+	normalizeComment,
+	normalizeIssueStateChange,
+	normalizeLabelChange,
+	normalizeNewIssue,
+	normalizePriorityChange,
+} from '@orgloop/connector-linear';
+import type {
+	OrgLoopEvent,
+	PollResult,
+	SourceConfig,
+	SourceConnector,
+	WebhookHandler,
+} from '@orgloop/sdk';
+import { buildEvent } from '@orgloop/sdk';
+
+export interface LinearWebhookConfig {
+	/** HMAC signing secret for validating webhook signatures */
+	secret?: string;
+	/** URL path to mount the webhook handler on */
+	path?: string;
+	/** Event types to accept (e.g., ["Issue", "Comment"]) */
+	events?: string[];
+	/** Optional team key filter — only process events for this team */
+	team?: string;
+	/** Directory for persisting buffered events across restarts */
+	buffer_dir?: string;
+}
+
+/** Resolve env var references like ${LINEAR_WEBHOOK_SECRET} */
+function resolveEnvVar(value: string): string {
+	const match = value.match(/^\$\{(.+)\}$/);
+	if (match) {
+		const envValue = process.env[match[1]];
+		if (!envValue) {
+			throw new Error(`Environment variable ${match[1]} is not set`);
+		}
+		return envValue;
+	}
+	return value;
+}
+
+export class LinearWebhookSource implements SourceConnector {
+	readonly id = 'linear-webhook';
+	private secret?: string;
+	private sourceId = 'linear-webhook';
+	private allowedEvents?: Set<string>;
+	private teamFilter?: string;
+	private pendingEvents: OrgLoopEvent[] = [];
+	private bufferPath?: string;
+
+	async init(config: SourceConfig): Promise<void> {
+		this.sourceId = config.id;
+		const cfg = config.config as unknown as LinearWebhookConfig;
+
+		if (cfg.secret) {
+			this.secret = resolveEnvVar(cfg.secret);
+		}
+
+		if (cfg.events && cfg.events.length > 0) {
+			this.allowedEvents = new Set(cfg.events);
+		}
+
+		if (cfg.team) {
+			this.teamFilter = cfg.team;
+		}
+
+		if (cfg.buffer_dir) {
+			const dir = resolveEnvVar(cfg.buffer_dir);
+			if (!existsSync(dir)) {
+				mkdirSync(dir, { recursive: true });
+			}
+			this.bufferPath = join(dir, `linear-webhook-${this.sourceId}.jsonl`);
+			this.loadBufferedEvents();
+		}
+	}
+
+	async poll(_checkpoint: string | null): Promise<PollResult> {
+		let events: OrgLoopEvent[];
+		if (this.bufferPath) {
+			events = this.loadBufferedEvents();
+			writeFileSync(this.bufferPath, '');
+		} else {
+			events = [...this.pendingEvents];
+			this.pendingEvents = [];
+		}
+		const checkpoint =
+			events.length > 0 ? events[events.length - 1].timestamp : new Date().toISOString();
+		return { events, checkpoint };
+	}
+
+	webhook(): WebhookHandler {
+		return async (req: IncomingMessage, res: ServerResponse): Promise<OrgLoopEvent[]> => {
+			if (req.method !== 'POST') {
+				res.writeHead(405, { 'Content-Type': 'application/json' });
+				res.end(JSON.stringify({ error: 'Method not allowed' }));
+				return [];
+			}
+
+			const bodyStr = await readBody(req);
+
+			// HMAC-SHA256 signature validation
+			if (this.secret) {
+				const signature = req.headers['linear-signature'] as string | undefined;
+				if (!signature) {
+					res.writeHead(401, { 'Content-Type': 'application/json' });
+					res.end(JSON.stringify({ error: 'Missing Linear-Signature header' }));
+					return [];
+				}
+
+				const expected = createHmac('sha256', this.secret).update(bodyStr).digest('hex');
+				const sigBuffer = Buffer.from(signature);
+				const expectedBuffer = Buffer.from(expected);
+				if (
+					sigBuffer.length !== expectedBuffer.length ||
+					!timingSafeEqual(sigBuffer, expectedBuffer)
+				) {
+					res.writeHead(401, { 'Content-Type': 'application/json' });
+					res.end(JSON.stringify({ error: 'Invalid signature' }));
+					return [];
+				}
+			}
+
+			let payload: Record<string, unknown>;
+			try {
+				payload = JSON.parse(bodyStr) as Record<string, unknown>;
+			} catch {
+				res.writeHead(400, { 'Content-Type': 'application/json' });
+				res.end(JSON.stringify({ error: 'Invalid JSON payload' }));
+				return [];
+			}
+
+			// Linear webhook payloads have: action, type, data, url, createdAt, updatedFrom
+			const resourceType = payload.type as string | undefined;
+			const action = payload.action as string | undefined;
+			if (!resourceType || !action) {
+				res.writeHead(400, { 'Content-Type': 'application/json' });
+				res.end(JSON.stringify({ error: 'Missing type or action field' }));
+				return [];
+			}
+
+			// Team filter: if configured, only accept events for the specified team
+			if (this.teamFilter) {
+				const data = payload.data as Record<string, unknown> | undefined;
+				const team = data?.team as Record<string, unknown> | undefined;
+				const teamKey = team?.key as string | undefined;
+				if (teamKey && teamKey !== this.teamFilter) {
+					res.writeHead(200, { 'Content-Type': 'application/json' });
+					res.end(JSON.stringify({ ok: true, filtered: true, reason: 'team_mismatch' }));
+					return [];
+				}
+			}
+
+			const events = this.normalizeWebhookPayload(resourceType, action, payload);
+
+			for (const event of events) {
+				this.persistEvent(event);
+			}
+
+			res.writeHead(200, { 'Content-Type': 'application/json' });
+			res.end(
+				JSON.stringify({
+					ok: true,
+					events_created: events.length,
+					event_ids: events.map((e) => e.id),
+				}),
+			);
+			return events;
+		};
+	}
+
+	async shutdown(): Promise<void> {
+		this.pendingEvents = [];
+	}
+
+	/**
+	 * Normalize a Linear webhook payload into OrgLoop events.
+	 * Uses the same normalizer functions as the polling connector to produce
+	 * identical event shapes.
+	 */
+	normalizeWebhookPayload(
+		resourceType: string,
+		action: string,
+		payload: Record<string, unknown>,
+	): OrgLoopEvent[] {
+		const data = payload.data as Record<string, unknown> | undefined;
+		if (!data) return [];
+
+		const updatedFrom = payload.updatedFrom as Record<string, unknown> | undefined;
+
+		switch (resourceType) {
+			case 'Issue': {
+				if (!this.isEventAllowed('Issue')) return [];
+				return this.normalizeIssueEvent(action, data, updatedFrom);
+			}
+
+			case 'Comment': {
+				if (!this.isEventAllowed('Comment')) return [];
+				if (action !== 'create') return this.buildRawEvent(resourceType, action, payload);
+				return this.normalizeCommentEvent(data);
+			}
+
+			default:
+				return this.buildRawEvent(resourceType, action, payload);
+		}
+	}
+
+	private normalizeIssueEvent(
+		action: string,
+		data: Record<string, unknown>,
+		updatedFrom?: Record<string, unknown>,
+	): OrgLoopEvent[] {
+		if (action === 'create') {
+			return [
+				normalizeNewIssue(this.sourceId, {
+					id: data.id as string,
+					identifier: data.identifier as string,
+					title: data.title as string,
+					description: data.description as string | null,
+					url: data.url as string,
+					state: { name: ((data.state as Record<string, unknown>)?.name as string) ?? 'Unknown' },
+					creator: data.creator as { name: string; isBot?: boolean } | null,
+					createdAt: data.createdAt as string,
+				}),
+			];
+		}
+
+		if (action === 'update' && updatedFrom) {
+			const events: OrgLoopEvent[] = [];
+			const issueBase = {
+				identifier: data.identifier as string,
+				title: data.title as string,
+				url: data.url as string,
+				assignee: data.assignee as { name: string; isBot?: boolean } | null,
+				updatedAt: data.updatedAt as string,
+			};
+
+			// State change
+			if (updatedFrom.state !== undefined) {
+				const previousState = (updatedFrom.state as Record<string, unknown>)?.name as
+					| string
+					| undefined;
+				const currentState = ((data.state as Record<string, unknown>)?.name as string) ?? 'Unknown';
+				events.push(
+					normalizeIssueStateChange(
+						this.sourceId,
+						{ id: data.id as string, state: { name: currentState }, ...issueBase },
+						previousState,
+					),
+				);
+			}
+
+			// Assignee change
+			if (updatedFrom.assigneeId !== undefined) {
+				const previousAssignee =
+					((updatedFrom.assignee as Record<string, unknown>)?.name as string | null) ?? null;
+				events.push(normalizeAssigneeChange(this.sourceId, issueBase, previousAssignee));
+			}
+
+			// Priority change
+			if (updatedFrom.priority !== undefined) {
+				events.push(
+					normalizePriorityChange(
+						this.sourceId,
+						issueBase,
+						updatedFrom.priority as number,
+						data.priority as number,
+					),
+				);
+			}
+
+			// Label change
+			if (updatedFrom.labelIds !== undefined) {
+				const prevLabels = ((updatedFrom.labels ?? []) as Array<{ name: string }>).map(
+					(l) => l.name,
+				);
+				const newLabels = ((data.labels as Array<{ name: string }>) ?? []).map((l) => l.name);
+				events.push(normalizeLabelChange(this.sourceId, issueBase, prevLabels, newLabels));
+			}
+
+			if (events.length > 0) return events;
+		}
+
+		// Fallback for unrecognized issue actions (remove, etc.)
+		return this.buildRawEvent('Issue', action, { data });
+	}
+
+	private normalizeCommentEvent(data: Record<string, unknown>): OrgLoopEvent[] {
+		const issue = data.issue as Record<string, unknown> | undefined;
+		return [
+			normalizeComment(
+				this.sourceId,
+				{
+					id: data.id as string,
+					body: data.body as string,
+					url: data.url as string,
+					createdAt: data.createdAt as string,
+					user: data.user as { name: string; isBot?: boolean } | null,
+				},
+				{
+					identifier: (issue?.identifier as string) ?? 'unknown',
+					title: (issue?.title as string) ?? '',
+					assignee: issue?.assignee as { name: string } | null,
+					creator: issue?.creator as { name: string } | null,
+				},
+			),
+		];
+	}
+
+	private isEventAllowed(eventType: string): boolean {
+		if (!this.allowedEvents) return true;
+		return this.allowedEvents.has(eventType);
+	}
+
+	private buildRawEvent(
+		resourceType: string,
+		action: string,
+		payload: Record<string, unknown>,
+	): OrgLoopEvent[] {
+		return [
+			buildEvent({
+				source: this.sourceId,
+				type: 'resource.changed',
+				provenance: {
+					platform: 'linear',
+					platform_event: `${resourceType.toLowerCase()}.${action}`,
+				},
+				payload,
+			}),
+		];
+	}
+
+	private persistEvent(event: OrgLoopEvent): void {
+		if (this.bufferPath) {
+			appendFileSync(this.bufferPath, `${JSON.stringify(event)}\n`);
+		} else {
+			this.pendingEvents.push(event);
+		}
+	}
+
+	private loadBufferedEvents(): OrgLoopEvent[] {
+		if (!this.bufferPath || !existsSync(this.bufferPath)) {
+			return [];
+		}
+		const content = readFileSync(this.bufferPath, 'utf-8').trim();
+		if (!content) {
+			return [];
+		}
+		return content.split('\n').map((line) => JSON.parse(line) as OrgLoopEvent);
+	}
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		req.on('data', (chunk: Buffer) => chunks.push(chunk));
+		req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+		req.on('error', reject);
+	});
+}

--- a/connectors/linear-webhook/tsconfig.json
+++ b/connectors/linear-webhook/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"],
+  "references": [
+    { "path": "../../packages/sdk" }
+  ]
+}

--- a/connectors/linear/src/index.ts
+++ b/connectors/linear/src/index.ts
@@ -6,6 +6,15 @@ import type { ConnectorRegistration } from '@orgloop/sdk';
 import { LinearSource } from './source.js';
 import { LinearCredentialValidator } from './validator.js';
 
+export {
+	normalizeAssigneeChange,
+	normalizeComment,
+	normalizeIssueStateChange,
+	normalizeLabelChange,
+	normalizeNewIssue,
+	normalizePriorityChange,
+} from './normalizer.js';
+
 export default function register(): ConnectorRegistration {
 	return {
 		id: 'linear',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,15 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sdk
 
+  connectors/linear-webhook:
+    dependencies:
+      '@orgloop/connector-linear':
+        specifier: workspace:*
+        version: link:../linear
+      '@orgloop/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+
   connectors/openclaw:
     dependencies:
       '@orgloop/sdk':


### PR DESCRIPTION
Adds `@orgloop/connector-linear-webhook` for real-time Linear events. Follows the github-webhook connector pattern. 29 tests passing, typecheck/lint clean. Closes #124.