### PR TITLE
release: v0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-03-20
+
+fix(connector-linear-webhook): recognize stateId in updatedFrom for state change detection
+
+
 ## [0.7.4] - 2026-03-19
 
 fix: re-export normalizer functions from connector-linear and connector-github entry points


### PR DESCRIPTION
## Release v0.7.4

### Changes
- **fix(connector-linear-webhook):** recognize `stateId` in `updatedFrom` for state change detection

Linear webhook payloads send `updatedFrom.stateId` (UUID) for state changes, not `updatedFrom.state` (object). This caused all state-change events to be normalized as generic `issue.update` instead of `issue.state_changed`, silently breaking routes that filter on state transitions.

Closes #137