### PR TITLE
release: v0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.7.5] - 2026-03-24
+
+feat(connector-openclaw): add lane support for concurrency control (#140)
+
+
 ## [0.7.4] - 2026-03-20
 
 fix(connector-linear-webhook): recognize stateId in updatedFrom for state change detection

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
   "dependencies": {
     "@orgloop/transform-agent-gate": "workspace:^"
   },
-  "version": "0.7.4"
+  "version": "0.7.5"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/cli",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "OrgLoop command-line interface",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/core",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "OrgLoop runtime engine — library-first event routing",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/sdk",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "OrgLoop plugin development kit — interfaces, base classes, and test harnesses",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/server",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "OrgLoop HTTP API server",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.7.5

- Version bump: 0.7.4 → 0.7.5 (patch)
- CHANGELOG.md updated
- Build + tests passed

### Post-merge steps

```bash
git checkout main && git pull origin main
git tag v0.7.5
git push origin v0.7.5
```